### PR TITLE
Add ability to get alternate photos for a location by a photo identifier

### DIFF
--- a/backend/src/api/PhotosResource.ts
+++ b/backend/src/api/PhotosResource.ts
@@ -22,8 +22,6 @@ router.get('/', async (req, res) => {
       [withSameLngLatByIdentifier]
     );
 
-    console.log(lngLatForFromIdentifierResult);
-
     if (!lngLatForFromIdentifierResult) {
       res.status(401).send('cannot find by identifier');
       return;
@@ -33,7 +31,6 @@ router.get('/', async (req, res) => {
     lng = lngLatForFromIdentifierResult.lng_lat.x;
     lat = lngLatForFromIdentifierResult.lng_lat.y;
   }
-  console.log(lng, lat);
 
   if (!lng || !lat) {
     res.status(401).send('lngLat required');


### PR DESCRIPTION
previously required a lat,lng which the frontend does not have—only the photo identifier is in the URL and geojson