### PR TITLE
Auto merge patch dependabots

### DIFF
--- a/.github/workflows/backend-pr-not-required.yml
+++ b/.github/workflows/backend-pr-not-required.yml
@@ -1,0 +1,11 @@
+name: backend-pr
+on:
+  pull_request:
+    paths-ignore:
+      - "backend/**"
+
+jobs:
+  dryDeploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/frontend-pr-not-required.yml
+++ b/.github/workflows/frontend-pr-not-required.yml
@@ -1,0 +1,11 @@
+name: frontend-pr
+on:
+  pull_request:
+    paths-ignore:
+      - "backend/**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/frontend-pr.yml
+++ b/.github/workflows/frontend-pr.yml
@@ -8,7 +8,7 @@ defaults:
     shell: bash
     working-directory: frontend
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Attempt to auto-merge patch dependabots

Add dummy passing job when there is not a backend PR to support making this a required status check.

Want to make sure dependabot does not merge failing jobs.