### PR TITLE
Refactor Announcement Banner / Add Call for Help and New Feature Announcements

### DIFF
--- a/frontend/src/screens/App/screens/AnnouncementBanner/Announcement.ts
+++ b/frontend/src/screens/App/screens/AnnouncementBanner/Announcement.ts
@@ -1,0 +1,7 @@
+interface Announcment {
+  id: string;
+  expiresAt: Date;
+  render: () => React.ReactNode;
+}
+
+export default Announcment;

--- a/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementBannerStore.tsx
+++ b/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementBannerStore.tsx
@@ -1,0 +1,69 @@
+import create from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { persist } from 'zustand/middleware';
+import ANNOUNCEMENTS_REGISTRY from './AnnouncementRegistry';
+import React from 'react';
+import Announcement from './Announcement';
+
+interface State {
+  dismissals: string[];
+}
+
+interface Actions {
+  dismiss(id: string): void;
+}
+
+interface ComputedState {
+  announcementToDisplay: Announcement | null;
+}
+
+const useAnnouncementBannerStore = create(
+  persist(
+    immer<State & Actions>((set) => ({
+      dismissals: [],
+      dismiss: (id: string) => {
+        set((state) => {
+          state.dismissals.push(id);
+        });
+      },
+    })),
+    {
+      name: 'announcement-banner',
+      getStorage: () => localStorage,
+    }
+  )
+);
+
+export function useAnnouncementBannerStoreComputeds(): ComputedState {
+  const { dismissals } = useAnnouncementBannerStore();
+  const [now, setNow] = React.useState(Date.now());
+
+  // Keep the current time up to date
+  React.useEffect(() => {
+    const handle = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => {
+      clearInterval(handle);
+    };
+  });
+
+  const announcementToDisplay: Announcement | null = React.useMemo(() => {
+    const activeAnnouncements = ANNOUNCEMENTS_REGISTRY.filter(
+      (announcement) => {
+        return (
+          announcement.expiresAt.getTime() > now &&
+          !dismissals.includes(announcement.id)
+        );
+      }
+    );
+
+    return activeAnnouncements[0] || null;
+  }, [dismissals, now]);
+
+  return {
+    announcementToDisplay,
+  };
+}
+
+export default useAnnouncementBannerStore;

--- a/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementRegistry.tsx
+++ b/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementRegistry.tsx
@@ -18,8 +18,7 @@ const ANNOUNCEMENTS_REGISTRY: Announcment[] = [
     render: () => (
       <React.Fragment>
         Are you a frontend or fullstack engineer? Seeking a volunteer to help
-        with <i>1940s.nyc</i>.{' '}
-        <a href="mailto:julianboilen+fourtiesnyc@gmail.com">Contact me</a>
+        with <i>1940s.nyc</i>. <a href="mailto:julian@1940s.nyc">Contact me</a>
       </React.Fragment>
     ),
   },

--- a/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementRegistry.tsx
+++ b/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementRegistry.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Announcment from './Announcement';
+
+const ANNOUNCEMENTS_REGISTRY: Announcment[] = [
+  {
+    id: 'announcement-1',
+    expiresAt: new Date('2024-01-01'),
+    render: () => <React.Fragment>Announcement 1</React.Fragment>,
+  },
+  {
+    id: 'announcement-2',
+    expiresAt: new Date('2024-01-01'),
+    render: () => <React.Fragment>Announcement 2</React.Fragment>,
+  },
+];
+
+export default ANNOUNCEMENTS_REGISTRY;

--- a/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementRegistry.tsx
+++ b/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementRegistry.tsx
@@ -3,14 +3,25 @@ import Announcment from './Announcement';
 
 const ANNOUNCEMENTS_REGISTRY: Announcment[] = [
   {
-    id: 'announcement-1',
-    expiresAt: new Date('2024-01-01'),
-    render: () => <React.Fragment>Announcement 1</React.Fragment>,
+    id: 'storytelling-launch',
+    expiresAt: new Date('2023-03-01'),
+    render: () => (
+      <React.Fragment>
+        <b>New:</b> Click <i>Know This Place?</i> on any photo to contribute
+        your knowledge and stories.
+      </React.Fragment>
+    ),
   },
   {
-    id: 'announcement-2',
-    expiresAt: new Date('2024-01-01'),
-    render: () => <React.Fragment>Announcement 2</React.Fragment>,
+    id: 'call-for-help',
+    expiresAt: new Date('2023-02-01'),
+    render: () => (
+      <React.Fragment>
+        Are you a frontend or fullstack engineer? Seeking a volunteer to help
+        with <i>1940s.nyc</i>.{' '}
+        <a href="mailto:julianboilen+fourtiesnyc@gmail.com">Contact me</a>
+      </React.Fragment>
+    ),
   },
 ];
 

--- a/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementRegistry.tsx
+++ b/frontend/src/screens/App/screens/AnnouncementBanner/AnnouncementRegistry.tsx
@@ -4,7 +4,7 @@ import Announcment from './Announcement';
 const ANNOUNCEMENTS_REGISTRY: Announcment[] = [
   {
     id: 'storytelling-launch',
-    expiresAt: new Date('2023-03-01'),
+    expiresAt: new Date('2023-04-07'),
     render: () => (
       <React.Fragment>
         <b>New:</b> Click <i>Know This Place?</i> on any photo to contribute

--- a/frontend/src/screens/App/screens/AnnouncementBanner/index.tsx
+++ b/frontend/src/screens/App/screens/AnnouncementBanner/index.tsx
@@ -1,46 +1,23 @@
 import React from 'react';
 
 import stylesheet from './AnnouncementBanner.less';
-
-const DISPLAY_UNTIL = new Date(2022, 4);
-const HIDE_KEY = 'alternatesBanner';
+import useAnnouncementBannerStore, {
+  useAnnouncementBannerStoreComputeds,
+} from './AnnouncementBannerStore';
 
 export default function AnnouncementBanner(): JSX.Element | null {
-  const [now, setNow] = React.useState(Date.now());
-  const [hidden, setHidden] = React.useState(
-    localStorage.getItem(HIDE_KEY) === 'true'
-  );
+  const dismiss = useAnnouncementBannerStore((state) => state.dismiss);
+  const { announcementToDisplay } = useAnnouncementBannerStoreComputeds();
 
-  React.useEffect(() => {
-    const handle = setInterval(() => {
-      setNow(Date.now());
-    }, 1000);
-    return () => {
-      clearInterval(handle);
-    };
-  });
+  if (!announcementToDisplay) return null;
 
   const hide = (): void => {
-    localStorage.setItem(HIDE_KEY, 'true');
-    setHidden(true);
+    dismiss(announcementToDisplay.id);
   };
-
-  const diffS = (DISPLAY_UNTIL.getTime() - now) / 1000;
-
-  if (diffS < 0 || hidden) return null;
-
-  // const days = Math.floor(diffS / 86400);
-  // let remS = diffS - days * 86400;
-  // const hours = Math.floor(remS / 3600);
-  // remS -= hours * 3600;
-  // const mins = Math.floor(remS / 60);
-  // remS -= mins * 60;
-  // const sec = Math.floor(remS);
 
   return (
     <div className={stylesheet.container}>
-      New: Hover or tap on an image for more photos of the same location, where
-      available.{' '}
+      {announcementToDisplay.render()}{' '}
       <button className={stylesheet.hideButton} onClick={hide}>
         Hide
       </button>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/406931/211173569-491afe23-e517-4486-8471-c09fea4f48a7.png)

Refactored the AnnouncementBanner to use a real store instead of the hacky inline thing I built for the dotnyc contest in 2020. 

Add two announcements
- The storytelling feature
- A call for an engineer volunteer