### PR TITLE
Backfill story titles with GPT-3

### DIFF
--- a/backend/cron.ts
+++ b/backend/cron.ts
@@ -4,6 +4,7 @@ import createConnection from './src/createConnection';
 
 import checkStaleStoriesImpl from './src/cron/checkStaleStories';
 import syncMapImpl from './src/cron/syncMap';
+import generateStoryTitlesImpl from './src/cron/generateStoryTitles';
 
 import * as Sentry from '@sentry/node';
 import { CaptureConsole as CaptureConsoleIntegration } from '@sentry/integrations';
@@ -39,4 +40,10 @@ export const syncMap = async (): Promise<void> => {
   await setup();
 
   await syncMapImpl();
+};
+
+export const generateStoryTitles = async (): Promise<void> => {
+  await setup();
+
+  await generateStoryTitlesImpl();
 };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,9 +23,9 @@
         "gotrue-js": "^0.9.29",
         "http-errors": "^2.0.0",
         "jsonstream": "npm:JSONStream@^1.3.5",
-        "JSONStream": "^1.3.5",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21",
+        "openai": "^3.2.1",
         "pg": "^8.8.0",
         "pg-query-stream": "^4.3.0",
         "postmark": "^3.0.15",
@@ -39,6 +39,8 @@
         "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "@tsconfig/recommended": "^1.0.2",
         "@types/aws-lambda": "^8.10.111",
         "@types/cors": "^2.8.12",
         "@types/eslint": "^8.4.6",
@@ -2711,6 +2713,18 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/recommended": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.2.tgz",
+      "integrity": "sha512-dbHBtbWBOjq0/otpopAE02NT2Cm05Qe2JsEKeCf/wjSYbI2hz8nCqnpnOJWHATgjDz4fd3dchs3Wy1gQGjfN6w==",
       "dev": true
     },
     "node_modules/@tsoa/cli": {
@@ -11063,6 +11077,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
+      "integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
+      "dependencies": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/openai/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -17780,6 +17811,18 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "dev": true
     },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "@tsconfig/recommended": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.2.tgz",
+      "integrity": "sha512-dbHBtbWBOjq0/otpopAE02NT2Cm05Qe2JsEKeCf/wjSYbI2hz8nCqnpnOJWHATgjDz4fd3dchs3Wy1gQGjfN6w==",
+      "dev": true
+    },
     "@tsoa/cli": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@tsoa/cli/-/cli-4.1.3.tgz",
@@ -24071,6 +24114,25 @@
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
+      }
+    },
+    "openai": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
+      "integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
+      "requires": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        }
       }
     },
     "optionator": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -68,6 +68,7 @@
     "jsonstream": "npm:JSONStream@^1.3.5",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
+    "openai": "^3.2.1",
     "pg": "^8.8.0",
     "pg-query-stream": "^4.3.0",
     "postmark": "^3.0.15",

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -28,6 +28,7 @@ provider:
     JWT_SECRET: ${ssm:/${self:service}-${sls:stage}-jwt-secret}
     MODERATORS_TO_EMAIL: ${ssm:/${self:service}-${sls:stage}-moderators-to-email}
     MAPBOX_SK: ${ssm:/${self:service}-${sls:stage}-mapbox-sk}
+    OPENAI_SK: ${ssm:/${self:service}-${sls:stage}-openai-sk}
 plugins:
   - serverless-plugin-select
   - serverless-offline
@@ -76,6 +77,13 @@ functions:
     handler: cron.syncMap
     events:
       - schedule: cron(0 4 * * ? *)
+    timeout: 900
+  generateStoryTitles:
+    stages:
+      - production
+    handler: cron.generateStoryTitles
+    events:
+      - schedule: cron(0 * * * ? *)
     timeout: 900
 custom:
   bucket: fourties-photos

--- a/backend/src/business/ai/AiService.ts
+++ b/backend/src/business/ai/AiService.ts
@@ -1,0 +1,15 @@
+import { Configuration, OpenAIApi } from 'openai';
+import createStoryTitlePrompt from './createStoryTitlePrompt';
+const configuration = new Configuration({
+  organization: 'org-TEbKEsj2LQsKAmHZRs1MoHHh',
+  apiKey: process.env.OPENAI_SK,
+});
+const openai = new OpenAIApi(configuration);
+
+export async function suggestStoryTitle(storyContent: string): Promise<string> {
+  const response = await openai.createCompletion(
+    createStoryTitlePrompt(storyContent)
+  );
+
+  return response.data.choices[0].text ?? '';
+}

--- a/backend/src/business/ai/createStoryTitlePrompt.ts
+++ b/backend/src/business/ai/createStoryTitlePrompt.ts
@@ -1,0 +1,28 @@
+import { CreateCompletionRequest } from 'openai';
+
+export default function createStoryTitlePrompt(
+  storyContent: string
+): CreateCompletionRequest {
+  return {
+    model: 'text-davinci-003',
+    prompt: `Create a very short caption for each story
+
+Story: I lived in the building with the peak from my birth in 1948 until I was 13 in 1961, with my parents and siblings.  The 3 windows right above the Bohack sign were in my parents bedroom.  My fathers parents and my aunts and uncles lived on Grattan St in various apartments over the years.  Those are the buildings to the left of my house. Very sad to see it now.
+Caption: My childhood home
+
+Story: The Tepedino's,  Michael and Angelina. ITALIAN immigrants from the Salerno area of Italy raised 3 children in this home.
+Caption: Italian immigrants raised family
+
+Story: That's old man Saso sitting on the stoop of 35 Snediker ave. He sat there every day for years.
+Caption: Man sat daily on stoop
+
+Story: ${storyContent.replaceAll('\n', ' ').trim()}
+Caption:`,
+    temperature: 0.1,
+    max_tokens: 8,
+    top_p: 1,
+    frequency_penalty: 0,
+    presence_penalty: 0,
+    stop: ['\n'],
+  };
+}

--- a/backend/src/business/geodata/GeojsonEncoder.ts
+++ b/backend/src/business/geodata/GeojsonEncoder.ts
@@ -19,6 +19,7 @@ type RawEffectiveGeocode = {
   record_method: string;
   record_lng_lat: { x: number; y: number };
   stories_storyteller_subtitle: string;
+  stories_title: string;
 };
 
 export default class GeojsonEncoder {
@@ -47,6 +48,7 @@ export default class GeojsonEncoder {
             'record.method',
             'record.lngLat',
             'stories.storytellerSubtitle',
+            'stories.title',
           ])
           .stream()
       )
@@ -66,21 +68,25 @@ export default class GeojsonEncoder {
     record_lng_lat: lngLat,
     record_identifier: photoIdentifier,
     stories_storyteller_subtitle,
-  }: RawEffectiveGeocode): Feature => ({
-    type: 'Feature',
-    geometry: {
-      type: 'Point',
-      coordinates: [lngLat.x, lngLat.y],
-    },
-    properties: stories_storyteller_subtitle
-      ? {
-          photoIdentifier,
-          storyLabel: stories_storyteller_subtitle,
-        }
-      : {
-          photoIdentifier,
-        },
-  });
+    stories_title,
+  }: RawEffectiveGeocode): Feature => {
+    const storyLabel = stories_title || stories_storyteller_subtitle;
+    return {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [lngLat.x, lngLat.y],
+      },
+      properties: storyLabel
+        ? {
+            photoIdentifier,
+            storyLabel: storyLabel,
+          }
+        : {
+            photoIdentifier,
+          },
+    };
+  };
 
   private get rowToFeatureTransform(): Transform {
     const rowToFeature = this.rowToFeature;

--- a/backend/src/cron/generateStoryTitles.ts
+++ b/backend/src/cron/generateStoryTitles.ts
@@ -1,0 +1,32 @@
+import { IsNull } from 'typeorm';
+import StoryRepository from '../repositories/StoryRepository';
+import * as AiService from '../business/ai/AiService';
+
+const LIMIT = 20;
+
+export default async function generateStoryTitles(): Promise<void> {
+  const repository = StoryRepository();
+  const stories = await repository
+    .createQueryBuilder('story')
+    .where({ title: IsNull() })
+    .limit(LIMIT)
+    .getMany();
+
+  stories.map(async (story) => {
+    const textContent = story.textContent;
+    if (!textContent) return;
+
+    try {
+      const suggestedTitle = await AiService.suggestStoryTitle(textContent);
+
+      await repository.update(story.id, {
+        title: suggestedTitle,
+        updatedAt: story.updatedAt,
+      });
+    } catch (e) {
+      console.warn('Could not generate title for story', story.id, e);
+    }
+  });
+
+  await Promise.all(stories);
+}

--- a/backend/src/entities/Story.ts
+++ b/backend/src/entities/Story.ts
@@ -40,6 +40,9 @@ export default class Story {
   @Column()
   storytellerSubtitle?: string;
 
+  @Column()
+  title?: string;
+
   @Column(PointColumnOptions)
   lngLat: LngLat | null;
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,6 +13,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "module": "commonjs",
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
   }
 }

--- a/backend/typings.d.ts
+++ b/backend/typings.d.ts
@@ -1,0 +1,2 @@
+// To satisfy the openai module, which uses this futuristic type
+type File = unknown;


### PR DESCRIPTION
Added `title` column to Story.

Use this, if set, as the label on the map.

Create a cron job to backfill these.
This may be sort of a temporary measure. I don't have a real migration framework, so a cron job works in lieu of a running a migration. Also, in the future we could do this on demand, or from the frontend to allow the user to customize. 

but that's the future. For now a simple cron job will function both as a backfill and an ongoing way to fill out the title. 

The generated titles are pretty good. I think they may be even better than what users enter, since users usually have terrible spelling, punctuation, capitalization, and may have trouble being terse. The AI is charmingly creative at coming up with short titles such as "Man sat daily on stoop"