### PR TITLE
Include map points not in collection that have stories

### DIFF
--- a/backend/src/business/geodata/GeojsonEncoder.ts
+++ b/backend/src/business/geodata/GeojsonEncoder.ts
@@ -39,10 +39,11 @@ export default class GeojsonEncoder {
           // ensure only one result per photo (even if there are multiple stories)
           // This lets us use the photo identifier as a unique identifier for the feature.
           .distinctOn(['record.identifier'])
-          .where({ collection })
           .leftJoin('record.stories', 'stories', 'stories.state = :state', {
             state: StoryState.PUBLISHED,
           })
+          .where({ collection })
+          .orWhere('stories.id IS NOT NULL')
           .select([
             'record.identifier',
             'record.method',


### PR DESCRIPTION
Usually we only want map points for 40s photos, since this is 1940s.nyc.
However, this would mean we would not show stories on 80s photos on the map.

So lets also put 80s photos on the map if they have stories.

```
SELECT DISTINCT ON ("record"."identifier") "record"."identifier" AS "record_identifier", "record"."method" AS "record_method", "record"."lng_lat" AS "record_lng_lat", "stories"."storyteller_subtitle" AS "stories_storyteller_subtitle", "stories"."title" AS "stories_title" FROM "effective_geocodes_view" "record" LEFT JOIN "stories" "stories" ON "stories"."photo"="record"."identifier" AND ("stories"."state" = $1) WHERE "record"."collection" = $2 OR "stories"."id" IS NOT NULL LIMIT 100 -- PARAMETERS: ["published","1940"]
```