### PR TITLE
New tip amounts

### DIFF
--- a/frontend/src/screens/App/screens/TipJar/useAmountPresets.ts
+++ b/frontend/src/screens/App/screens/TipJar/useAmountPresets.ts
@@ -1,16 +1,18 @@
-import { useExperimentVariants } from 'shared/utils/OptimizeExperiments';
+// import { useExperimentVariants } from 'shared/utils/OptimizeExperiments';
 
-const PRESET_OPTIONS_BY_VARIANT: Record<number, number[]> = {
-  0: [2, 8, 16, 20],
-  1: [5, 10, 20, 40],
-};
+// const PRESET_OPTIONS_BY_VARIANT: Record<number, number[]> = {
+//   0: [2, 8, 16, 20],
+//   1: [5, 10, 20, 40],
+// };
 
 export default function useAmountPresets(): number[] {
-  const [presetsVariant] = [
-    useExperimentVariants('wLWeVH_USHuTlkUtAK9Erw'),
-    [0],
-  ].find((v) => Array.isArray(v));
-  const amountPresets = PRESET_OPTIONS_BY_VARIANT[presetsVariant];
+  // const [presetsVariant] = [
+  //   useExperimentVariants('wLWeVH_USHuTlkUtAK9Erw'),
+  //   [0],
+  // ].find((v) => Array.isArray(v));
+  // const amountPresets = PRESET_OPTIONS_BY_VARIANT[presetsVariant];
 
-  return amountPresets;
+  // return amountPresets;
+
+  return [2, 10, 20, 40];
 }


### PR DESCRIPTION
I ran an experiment between 
Control: 2, 8, 16, 20
Treatment: 5, 10, 20, 40

And the treatment group did not convert as well in dollars or number of donations. However, some people did choose the $40 option.
So, this changes the presets to be a combination of both the high numbers and the low and popular $2 value.

I think this should work and I want to put it out without another experiment.