### PR TITLE
Remove 20 qty credit option

### DIFF
--- a/frontend/src/screens/App/screens/CreditPurchaseModal/stories/CreditPurchaseStore.ts
+++ b/frontend/src/screens/App/screens/CreditPurchaseModal/stories/CreditPurchaseStore.ts
@@ -4,7 +4,7 @@ import create from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { getMe, LoginOutcome, processLoginRequest } from '../utils/CreditsApi';
 
-const PRESET_QUANTITIES = [20, 50, 100, 200];
+const PRESET_QUANTITIES = [50, 100, 200];
 
 interface State {
   isOpen: boolean;


### PR DESCRIPTION
Encourage purchase of at least 50.

Profit.

(Need to increase revenue to cover free usage)