### PR TITLE
Update backend runtime to 20 to match development version

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -4,7 +4,7 @@ package:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   stage: production
   region: us-east-1
   iam:


### PR DESCRIPTION
Node was updated to 20 for development, building but set to use the node 16 runtime in prod!