### PR TITLE
Switch palette api to new host

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -30,7 +30,7 @@ provider:
     MODERATORS_TO_EMAIL: ${ssm:/${self:service}-${sls:stage}-moderators-to-email}
     MAPBOX_SK: ${ssm:/${self:service}-${sls:stage}-mapbox-sk}
     OPENAI_SK: ${ssm:/${self:service}-${sls:stage}-openai-sk}
-    PALETTE_API_KEY: ${ssm:/${self:service}-${sls:stage}-palette-api-key}
+    RAPIDAPI_API_KEY: ${ssm:/${self:service}-${sls:stage}-rapidapi-api-key}
 plugins:
   - serverless-plugin-select
   - serverless-plugin-typescript

--- a/backend/src/business/utils/paletteApi.ts
+++ b/backend/src/business/utils/paletteApi.ts
@@ -25,9 +25,13 @@ type ColorizeImageWithAutoPromptBase64Request = {
 };
 
 const paletteApi = axios.create({
-  baseURL: 'https://apis.palette.fm/1a0ffbmqnpuf3uzj',
+  baseURL: 'https://colorize-photo1.p.rapidapi.com/',
   headers: {
-    'X-BLOBR-KEY': required(process.env.PALETTE_API_KEY, 'PALETTE_API_KEY'),
+    'X-RapidAPI-Key': required(
+      process.env.RAPIDAPI_API_KEY,
+      'RAPIDAPI_API_KEY'
+    ),
+    'X-RapidAPI-Host': 'colorize-photo1.p.rapidapi.com',
     'Content-Type': 'multipart/form-data',
   },
 });


### PR DESCRIPTION
Emil (from Palette) says the old one is going away on Jan 31

Palette.fm is transitioning to a new host.

*Important*: API keys must be uploaded to SSM for this new API parameter before merging!

Changed the env var name so it could be a seamless rollout