### PR TITLE
Increase height breakpoint for modals

### DIFF
--- a/frontend/src/shared/components/Modal/index.tsx
+++ b/frontend/src/shared/components/Modal/index.tsx
@@ -11,7 +11,7 @@ import ReactModal from 'react-modal';
 import stylesheet from './modal.less';
 
 const MODAL_WIDTH_MAX = 800; // @modal-width-max
-const MODAL_HEIGHT_MAX = 600; // @modal-height-max
+const MODAL_HEIGHT_MAX = 725; // @modal-height-max
 
 export type FourtiesModalProps = React.PropsWithChildren<ReactModal.Props> & {
   size: 'large' | 'small' | 'x-large';

--- a/frontend/src/shared/styles/viewport.less
+++ b/frontend/src/shared/styles/viewport.less
@@ -1,2 +1,2 @@
-@modal-height-max: 600px;
+@modal-height-max: 725px;
 @modal-width-max: 800px;


### PR DESCRIPTION
Based on a user reported issue, there were some heights where the top of the modal and close button were cut off. So now we switch to mobile view sooner.

Before
![Kapture 2025-02-25 at 10 00 09](https://github.com/user-attachments/assets/2363700b-4060-436f-ac92-9e9030c1c1e6)
