### PR TITLE
Replace mapwarper with self-hosted 1930 Manhattan Atlas

### DIFF
--- a/frontend/src/screens/App/screens/MapPane/components/MainMap/overlays.ts
+++ b/frontend/src/screens/App/screens/MapPane/components/MainMap/overlays.ts
@@ -95,10 +95,11 @@ export const installLayers = (
       bounds: MANHATTAN,
     },
     {
-      url: 'https://mapwarper.net/mosaics/tile/1194/{z}/{x}/{y}.png',
+      url: 'https://maptiles.1940s.nyc/manhattan-atlas-1930/webp-lossy-hi/{z}/{x}/{y}.webp',
       targetId: 'atlas-1930',
       attribution: '[1930] ' + NYPL_ATTRIBUTION,
       bounds: MANHATTAN,
+      maxzoom: 20,
     },
     {
       url: 'https://nypl-tiles.1940s.nyc/1453/{z}/{x}/{y}.png',
@@ -130,6 +131,7 @@ export const installLayers = (
       ...(mapSpec.bounds
         ? { bounds: mapSpec.bounds as [number, number, number, number] }
         : {}),
+      ...(mapSpec.maxzoom ? { maxzoom: mapSpec.maxzoom } : {}),
     });
 
     map.addLayer(


### PR DESCRIPTION
Tiles are compressed to webp. Webp is now well supported.

One oddity is that I pulled different zoom levels at different times. Some in 2023, some recently. They seem to have different crops. Maybe someone updated some of the plate cropping. So when you zoom some crops can change.

They are served by Cloudfront with http/2 which allows more tiles to be loaded simultaneously.

Mapwarper has been having intermittent DNS issues for me and not working a lot of the time.

⚠️ In 2020 I tried directly proxying Mapwarper on using Cloudfront with edge compression. It was incredibly expensive. I believe the main costs were the outbound bandwidth from the internet for the soruce, while this uses s3 which has no bandwidth cost. Watch costs!