### PR TITLE
chore(backend): upgrade typeorm connections

### DIFF
--- a/backend/src/api/CorrectionsController.ts
+++ b/backend/src/api/CorrectionsController.ts
@@ -1,7 +1,7 @@
 import { Body, Post, Request, Route, Security } from '@tsoa/runtime';
 import * as express from 'express';
 import { Forbidden } from 'http-errors';
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../createConnection';
 import * as UserService from '../business/users/UserService';
 import AddressCorrection from '../entities/AddressCorrection';
 import GeocodeCorrection from '../entities/GeocodeCorrection';
@@ -49,7 +49,8 @@ export class CorrectionsController {
 
     const userId = await getUserIdFromRequestForCorrection(req);
 
-    const correctionsRepository = getRepository(GeocodeCorrection);
+    const correctionsRepository =
+      AppDataSource.getRepository(GeocodeCorrection);
 
     const corrections = photos.map((photo) => {
       const correction = new GeocodeCorrection();
@@ -72,7 +73,8 @@ export class CorrectionsController {
 
     const userId = await getUserIdFromRequestForCorrection(req);
 
-    const correctionsRepository = getRepository(AddressCorrection);
+    const correctionsRepository =
+      AppDataSource.getRepository(AddressCorrection);
 
     const corrections = photos.map((photo) => {
       const correction = new AddressCorrection();

--- a/backend/src/api/merch/MerchController.ts
+++ b/backend/src/api/merch/MerchController.ts
@@ -12,7 +12,7 @@ import {
 } from '@tsoa/runtime';
 import * as express from 'express';
 import { BadRequest, NotFound } from 'http-errors';
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../../createConnection';
 import * as MerchOrderService from '../../business/merch/MerchOrderService';
 import absurd from '../../business/utils/absurd';
 import { getPrintfileUrl } from '../../business/utils/printfileUtils';
@@ -31,7 +31,7 @@ export class MerchController extends Controller {
     id: number,
     userId: number
   ): Promise<MerchOrderItem> {
-    const merchItemRepository = getRepository(MerchOrderItem);
+    const merchItemRepository = AppDataSource.getRepository(MerchOrderItem);
     const item = await merchItemRepository
       .createQueryBuilder('item')
       .innerJoinAndSelect('item.order', 'order')
@@ -59,7 +59,7 @@ export class MerchController extends Controller {
     }
 
     item.customizationOptions = customizationOptions;
-    await getRepository(MerchOrderItem).save(item);
+    await AppDataSource.getRepository(MerchOrderItem).save(item);
   }
 
   @Post('items/{itemId}/finalize-customizations')
@@ -69,7 +69,7 @@ export class MerchController extends Controller {
     @Request() req: express.Request
   ): Promise<void> {
     const userId = await getUserFromRequestOrCreateAndSetCookie(req);
-    const merchItemRepository = getRepository(MerchOrderItem);
+    const merchItemRepository = AppDataSource.getRepository(MerchOrderItem);
     const item = await this.getAccessibleMerchItem(itemId, userId);
 
     if (item.state !== MerchItemState.PURCHASED) {
@@ -108,7 +108,7 @@ export class MerchController extends Controller {
     @Body() updates: { state: MerchOrderState }
   ): Promise<MerchOrderApiModel> {
     const { state: newState } = updates;
-    const orderRepository = getRepository(MerchOrder);
+    const orderRepository = AppDataSource.getRepository(MerchOrder);
     let order = await orderRepository.findOneByOrFail({ id: orderId });
 
     switch (newState) {
@@ -151,7 +151,7 @@ export class MerchController extends Controller {
     @Request() req: express.Request
   ): Promise<MerchOrderApiModel[]> {
     const userId = await getUserFromRequestOrCreateAndSetCookie(req);
-    const orders = await getRepository(MerchOrder)
+    const orders = await AppDataSource.getRepository(MerchOrder)
       .createQueryBuilder('order')
       .innerJoinAndSelect('order.items', 'items')
       .innerJoinAndSelect('order.user', 'user')

--- a/backend/src/api/photos/PhotosController.ts
+++ b/backend/src/api/photos/PhotosController.ts
@@ -12,7 +12,8 @@ import {
 import * as express from 'express';
 import { BadRequest, NotFound } from 'http-errors';
 import querystring from 'querystring';
-import { getRepository, In } from 'typeorm';
+import { In } from 'typeorm';
+import { AppDataSource } from '../../createConnection';
 import Paginated from '../../business/pagination/Paginated';
 import mapPaginated from '../../business/utils/mapPaginated';
 import Photo from '../../entities/Photo';
@@ -44,7 +45,7 @@ export class PhotosController extends Controller {
     @Query() lat?: string | number,
     @Query() withSameLngLatByIdentifier?: string
   ): Promise<PhotoApiModel[]> {
-    const photoRepo = getRepository(Photo);
+    const photoRepo = AppDataSource.getRepository(Photo);
 
     if (withSameLngLatByIdentifier) {
       const lngLatForFromIdentifierResult = await getLngLatForIdentifier(
@@ -87,7 +88,7 @@ export class PhotosController extends Controller {
     @Query() lat: string | number,
     @Query() collection?: '1940' | '1980'
   ): Promise<PhotoApiModel> {
-    const photoRepo = getRepository(Photo);
+    const photoRepo = AppDataSource.getRepository(Photo);
 
     const result: { identifier: string; distance: number }[] =
       await photoRepo.query(
@@ -114,7 +115,7 @@ export class PhotosController extends Controller {
     @Query('pageToken') pageToken?: string,
     @Query('pageSize') pageSize = 100
   ): Promise<Paginated<{ identifier: string }>> {
-    const photoRepo = getRepository(Photo);
+    const photoRepo = AppDataSource.getRepository(Photo);
 
     const qb = photoRepo
       .createQueryBuilder('photo')
@@ -144,7 +145,7 @@ export class PhotosController extends Controller {
   public async getByIdentifier(
     @Path() identifier: string
   ): Promise<PhotoApiModel> {
-    const photoRepo = getRepository(Photo);
+    const photoRepo = AppDataSource.getRepository(Photo);
 
     const photo = await photoRepo.findOne({
       where: { identifier },
@@ -163,7 +164,7 @@ export class PhotosController extends Controller {
     @Path() identifier: string,
     @Request() req: express.Request
   ): Promise<void> {
-    const photoRepo = getRepository(Photo);
+    const photoRepo = AppDataSource.getRepository(Photo);
 
     const photo = await photoRepo.findOneBy({
       identifier: identifier,
@@ -196,7 +197,7 @@ export class PhotosController extends Controller {
     @Request() req: express.Request
   ): Promise<void> {
     // Ensure this is a valid photo identifier so they can't get arbitrary s3 objects
-    const photoRepo = getRepository(Photo);
+    const photoRepo = AppDataSource.getRepository(Photo);
     const photoExists = await photoRepo.exists({
       where: { identifier: identifier },
     });

--- a/backend/src/business/geodata/GeojsonEncoder.ts
+++ b/backend/src/business/geodata/GeojsonEncoder.ts
@@ -2,7 +2,7 @@ import { Feature } from 'geojson';
 import gp from 'geojson-precision';
 import JSONStream from 'jsonstream';
 import { Transform } from 'stream';
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../../createConnection';
 import EffectiveGeocode from '../../entities/EffectiveGeocode';
 import StoryState from '../../enum/StoryState';
 
@@ -34,7 +34,7 @@ export default class GeojsonEncoder {
   ): Promise<NodeJS.ReadableStream> {
     return (
       (
-        await getRepository(EffectiveGeocode)
+        await AppDataSource.getRepository(EffectiveGeocode)
           .createQueryBuilder('record')
           // ensure only one result per photo (even if there are multiple stories)
           // This lets us use the photo identifier as a unique identifier for the feature.

--- a/backend/src/business/ledger/LedgerService.ts
+++ b/backend/src/business/ledger/LedgerService.ts
@@ -1,5 +1,6 @@
 import { TooManyRequests } from 'http-errors';
-import { getConnection, MoreThan, Repository } from 'typeorm';
+import { MoreThan, Repository } from 'typeorm';
+import { AppDataSource } from '../../createConnection';
 import LedgerEntry from '../../entities/LedgerEntry';
 import LedgerEntryType from '../../enum/LedgerEntryType';
 
@@ -15,7 +16,7 @@ export async function getBalance(
   ledgerRepository?: Repository<LedgerEntry>
 ): Promise<number> {
   if (!ledgerRepository) {
-    ledgerRepository = getConnection().getRepository(LedgerEntry);
+    ledgerRepository = AppDataSource.getRepository(LedgerEntry);
   }
   const { balance } = (await ledgerRepository
     .createQueryBuilder('entry')
@@ -34,7 +35,7 @@ async function hasEnoughBalance(
   ledgerRepository?: Repository<LedgerEntry>
 ): Promise<boolean> {
   if (!ledgerRepository) {
-    ledgerRepository = getConnection().getRepository(LedgerEntry);
+    ledgerRepository = AppDataSource.getRepository(LedgerEntry);
   }
   const balance = await getBalance(userId, ledgerRepository);
 
@@ -77,7 +78,7 @@ export async function withMeteredUsage<R>(
   photoIdentifier: string,
   wrapped: () => Promise<R>
 ): Promise<R> {
-  return getConnection().transaction(async (transactionalEntityManager) => {
+  return AppDataSource.transaction(async (transactionalEntityManager) => {
     const ledgerRepository =
       transactionalEntityManager.getRepository(LedgerEntry);
 
@@ -113,7 +114,7 @@ export async function grantCredits(
   amountCents: number,
   giveAmnesty = true
 ): Promise<void> {
-  const ledgerRepository = getConnection().getRepository(LedgerEntry);
+  const ledgerRepository = AppDataSource.getRepository(LedgerEntry);
 
   const balance = await getBalance(userId, ledgerRepository);
   const amnesty = balance < 0 ? -balance : 0;

--- a/backend/src/business/merch/MerchOrderService.ts
+++ b/backend/src/business/merch/MerchOrderService.ts
@@ -1,5 +1,5 @@
 import { BadRequest } from 'http-errors';
-import { getConnection, getRepository } from 'typeorm';
+import { AppDataSource } from '../../createConnection';
 import MerchOrder from '../../entities/MerchOrder';
 import MerchOrderItem from '../../entities/MerchOrderItem';
 import ShippingAddress from '../../entities/ShippingAddress';
@@ -39,7 +39,7 @@ export async function createMerchOrder(
   shippingAddress: ShippingAddress,
   itemTypes: MerchInternalVariant[]
 ): Promise<MerchOrder> {
-  return getConnection().transaction(async (transactionalEntityManager) => {
+  return AppDataSource.transaction(async (transactionalEntityManager) => {
     const orderRepository =
       transactionalEntityManager.getRepository(MerchOrder);
     let order = new MerchOrder();
@@ -97,7 +97,7 @@ export async function createOrderItems(
   order: MerchOrder,
   itemTypes: MerchInternalVariant[]
 ): Promise<MerchOrderItem[]> {
-  const itemRepository = getRepository(MerchOrderItem);
+  const itemRepository = AppDataSource.getRepository(MerchOrderItem);
   const items = itemTypes.map((type) => {
     const item = new MerchOrderItem();
     item.order = order;
@@ -110,7 +110,7 @@ export async function createOrderItems(
 export async function submitOrderForFulfillment(
   orderId: number
 ): Promise<void> {
-  const orderRepository = getRepository(MerchOrder);
+  const orderRepository = AppDataSource.getRepository(MerchOrder);
   const order = await orderRepository.findOneByOrFail({ id: orderId });
 
   switch (order.provider) {
@@ -128,7 +128,7 @@ export async function submitOrderForFulfillment(
 }
 
 export async function cancelOrder(orderId: number): Promise<void> {
-  const orderRepository = getRepository(MerchOrder);
+  const orderRepository = AppDataSource.getRepository(MerchOrder);
   const order = await orderRepository.findOneByOrFail({ id: orderId });
 
   if (
@@ -152,7 +152,7 @@ export async function onPrinterStatusChanged(
   providerOrderId: number,
   newFulfillmentState: MerchOrderFulfillmentState
 ): Promise<void> {
-  const orderRepository = getRepository(MerchOrder);
+  const orderRepository = AppDataSource.getRepository(MerchOrder);
   const order = await orderRepository.findOneBy({
     provider,
     providerOrderId,
@@ -195,7 +195,7 @@ export async function onShipmentSent(
   providerOrderId: number,
   trackingUrl: string
 ): Promise<void> {
-  const orderRepository = getRepository(MerchOrder);
+  const orderRepository = AppDataSource.getRepository(MerchOrder);
   let order = await orderRepository.findOneBy({
     provider,
     providerOrderId,
@@ -226,7 +226,7 @@ export async function onShipmentSent(
 }
 
 export async function getOrdersForReview(): Promise<MerchOrder[]> {
-  return getRepository(MerchOrder)
+  return AppDataSource.getRepository(MerchOrder)
     .createQueryBuilder('order')
     .innerJoinAndSelect('order.items', 'items')
     .innerJoinAndSelect('order.user', 'user')
@@ -236,7 +236,7 @@ export async function getOrdersForReview(): Promise<MerchOrder[]> {
 }
 
 export async function getOrdersWithExceptions(): Promise<MerchOrder[]> {
-  return await getRepository(MerchOrder)
+  return await AppDataSource.getRepository(MerchOrder)
     .createQueryBuilder('order')
     .innerJoinAndSelect('order.items', 'items')
     .innerJoinAndSelect('order.user', 'user')

--- a/backend/src/business/stories/StoriesService.ts
+++ b/backend/src/business/stories/StoriesService.ts
@@ -1,4 +1,4 @@
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../../createConnection';
 import Story from '../../entities/Story';
 import User from '../../entities/User';
 import StoryState from '../../enum/StoryState';
@@ -22,7 +22,7 @@ function getStoryOrThrow(
 
 async function onStorySubmitted(storyId: Story['id']): Promise<void> {
   const story = await getStoryOrThrow(storyId, StoryState.SUBMITTED);
-  const userRepository = getRepository(User);
+  const userRepository = AppDataSource.getRepository(User);
 
   const hasSubmittedBefore = story.hasEverSubmitted;
 

--- a/backend/src/business/users/UserService.ts
+++ b/backend/src/business/users/UserService.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import jwt from 'jsonwebtoken';
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../../createConnection';
 import User from '../../entities/User';
 import LoginOutcome from '../../enum/LoginOutcome';
 import stripe from '../../third-party/stripe';
@@ -62,7 +62,7 @@ export function getUserIdFromToken(
 }
 
 export function getUser(userId: number): Promise<User> {
-  const userRepository = getRepository(User);
+  const userRepository = AppDataSource.getRepository(User);
   return userRepository.findOneByOrFail({ id: userId });
 }
 
@@ -87,7 +87,7 @@ export async function attachStripeCustomerAndDetermineUserId(
 ): Promise<number> {
   if (email) email = normalizeEmail(email);
 
-  const userRepository = getRepository(User);
+  const userRepository = AppDataSource.getRepository(User);
   let user: User | null = null;
   if (requestUserId) {
     user = await userRepository.findOneBy({ id: requestUserId });
@@ -115,7 +115,7 @@ export async function attachStripeCustomerAndDetermineUserId(
 export async function getUserByStripeCustomerId(
   stripeCustomerId: string
 ): Promise<User | null> {
-  const userRepository = getRepository(User);
+  const userRepository = AppDataSource.getRepository(User);
   return userRepository.findOneBy({ stripeCustomerId });
 }
 
@@ -123,12 +123,12 @@ export async function updateSupportSubscription(
   userId: number,
   stripeSupportSubscriptionId: string | null
 ): Promise<void> {
-  const userRepository = getRepository(User);
+  const userRepository = AppDataSource.getRepository(User);
   await userRepository.update(userId, { stripeSupportSubscriptionId });
 }
 
 export async function markEmailVerified(userId: number): Promise<void> {
-  const userRepository = getRepository(User);
+  const userRepository = AppDataSource.getRepository(User);
   await userRepository.update(userId, { isEmailVerified: true });
 }
 
@@ -136,7 +136,7 @@ export async function createUser(
   ipAddress: string,
   email?: string
 ): Promise<{ token: string; userId: number }> {
-  const userRepository = getRepository(User);
+  const userRepository = AppDataSource.getRepository(User);
 
   let user = new User();
   user.ipAddress = ipAddress;
@@ -227,7 +227,7 @@ export async function processLoginRequest(
   requireVerifiedEmail = false,
   newEmailBehavior: 'update' | 'reject' | 'create' = 'update'
 ): Promise<LoginOutcome> {
-  const userRepository = getRepository(User);
+  const userRepository = AppDataSource.getRepository(User);
 
   const currentUser = await userRepository.findOneByOrFail({
     id: authenticatedUserId,

--- a/backend/src/cron/addMerchItemsToOrder.ts
+++ b/backend/src/cron/addMerchItemsToOrder.ts
@@ -1,4 +1,4 @@
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../createConnection';
 import * as PrintfulService from '../business/merch/PrintfulService';
 import MerchOrder from '../entities/MerchOrder';
 import MerchOrderItem from '../entities/MerchOrderItem';
@@ -8,8 +8,8 @@ import MerchOrderState from '../enum/MerchOrderState';
 const LIMIT = 5;
 
 export default async function addMerchItemsToOrder(): Promise<void> {
-  const itemRepository = getRepository(MerchOrderItem);
-  const orderRepository = getRepository(MerchOrder);
+  const itemRepository = AppDataSource.getRepository(MerchOrderItem);
+  const orderRepository = AppDataSource.getRepository(MerchOrder);
   const items = await itemRepository
     .createQueryBuilder('custom_merch_items')
     .leftJoinAndSelect('custom_merch_items.order', 'order')

--- a/backend/src/cron/renderMerchPrintfiles.ts
+++ b/backend/src/cron/renderMerchPrintfiles.ts
@@ -1,4 +1,4 @@
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../createConnection';
 import renderToteBag from '../business/merch/renderToteBag';
 import absurd from '../business/utils/absurd';
 import { uploadPrintfile } from '../business/utils/printfileUtils';
@@ -9,7 +9,7 @@ import MerchItemState from '../enum/MerchItemState';
 const LIMIT = 5;
 
 export default async function renderMerch(): Promise<void> {
-  const repository = getRepository(MerchOrderItem);
+  const repository = AppDataSource.getRepository(MerchOrderItem);
   const itemsToRender = await repository
     .createQueryBuilder('custom_merch_items')
     .where({

--- a/backend/src/cron/syncMapSelfHosted.ts
+++ b/backend/src/cron/syncMapSelfHosted.ts
@@ -1,6 +1,6 @@
 import { DeleteObjectCommand, ListObjectsV2Command, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { createReadStream } from 'fs';
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../createConnection';
 import GeojsonEncoder from '../business/geodata/GeojsonEncoder';
 import tippecanoe from '../business/utils/tippecanoe';
 import EffectiveAddress from '../entities/EffectiveAddress';
@@ -10,12 +10,12 @@ const s3 = new S3Client();
 
 export default async function syncMap(): Promise<void> {
   console.log('Refreshing effective addresses...');
-  await getRepository(EffectiveAddress).query(
+  await AppDataSource.getRepository(EffectiveAddress).query(
     'REFRESH MATERIALIZED VIEW effective_addresses_view WITH DATA'
   );
 
   console.log('Refreshing effective geocodes...');
-  await getRepository(EffectiveGeocode).query(
+  await AppDataSource.getRepository(EffectiveGeocode).query(
     'REFRESH MATERIALIZED VIEW effective_geocodes_view WITH DATA'
   );
 

--- a/backend/src/repositories/StoryRepository.ts
+++ b/backend/src/repositories/StoryRepository.ts
@@ -1,14 +1,15 @@
-import { Brackets, getRepository, In, IsNull, Repository } from 'typeorm';
+import { Brackets, In, IsNull, Repository } from 'typeorm';
 import Paginated from '../business/pagination/Paginated';
 import PaginationInput from '../business/pagination/PaginationInput';
 import Story from '../entities/Story';
 import StoryState from '../enum/StoryState';
 import getLngLatForIdentifier from './getLngLatForIdentifier';
 import { getPaginated } from './paginationUtils';
+import { AppDataSource } from '../createConnection';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- better type is inferred
 const StoryRepository = () =>
-  getRepository(Story).extend({
+  AppDataSource.getRepository(Story).extend({
     async findPublishedForPhotoIdentifier(
       this: Repository<Story>,
       identifier: string,

--- a/backend/src/repositories/getLngLatForIdentifier.ts
+++ b/backend/src/repositories/getLngLatForIdentifier.ts
@@ -1,11 +1,11 @@
-import { getRepository } from 'typeorm';
+import { AppDataSource } from '../createConnection';
 import EffectiveGeocode from '../entities/EffectiveGeocode';
 import LngLat from '../enum/LngLat';
 
 export default async function getLngLatForIdentifier(
   identifier: string
 ): Promise<LngLat | null> {
-  const geocodeRepo = getRepository(EffectiveGeocode);
+  const geocodeRepo = AppDataSource.getRepository(EffectiveGeocode);
 
   const lngLatForFromIdentifierResult = await geocodeRepo.findOneBy({
     identifier,


### PR DESCRIPTION
Replace deprecated `getConnection` and `getRepository` functions from typeorm in favor of `DataSource` instance

See: https://typeorm.io/docs/data-source/data-source/

---
https://trello.com/c/GcZKLBke