### PR TITLE
[Experimenting] Add Sentry AI monitoring for OpenAI backend

### DIFF
--- a/backend/src/business/ai/AiService.ts
+++ b/backend/src/business/ai/AiService.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import * as Sentry from '@sentry/node';
 import createStoryTitlePrompt from './createStoryTitlePrompt';
 
 const openai = new OpenAI({
@@ -7,9 +8,36 @@ const openai = new OpenAI({
 });
 
 export async function suggestStoryTitle(storyContent: string): Promise<string> {
-  const response = await openai.chat.completions.create(
-    createStoryTitlePrompt(storyContent)
-  );
+  const prompt = createStoryTitlePrompt(storyContent);
+  const model = typeof prompt.model === 'string' ? prompt.model : 'unknown';
+  const aiSpan = Sentry.getCurrentHub()
+    .getScope()
+    ?.getTransaction()
+    ?.startChild({
+      op: 'gen_ai.request',
+      description: `OpenAI chat completion (${model})`,
+    });
+  aiSpan?.setData('gen_ai.request.model', model);
 
-  return response.choices[0].message.content?.trim() ?? '';
+  try {
+    const response = await openai.chat.completions.create(prompt);
+
+    if (response.usage) {
+      aiSpan?.setData(
+        'gen_ai.usage.input_tokens',
+        response.usage.prompt_tokens
+      );
+      aiSpan?.setData(
+        'gen_ai.usage.output_tokens',
+        response.usage.completion_tokens
+      );
+    }
+
+    return response.choices[0].message.content?.trim() ?? '';
+  } catch (error) {
+    aiSpan?.setStatus('internal_error');
+    throw error;
+  } finally {
+    aiSpan?.finish();
+  }
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"452bd158-c882-46cb-83af-c15cb648c81a","source":"chat","resourceId":"4142638d-535a-4c29-9076-5fa98b6e5e2a","workflowId":"90a5131d-3dc5-4178-8cc2-249c6aa4b5e5","codeChangeId":"90a5131d-3dc5-4178-8cc2-249c6aa4b5e5","sourceType":"chat"} -->
## Summary
Add Sentry AI monitoring instrumentation around backend OpenAI story-title generation so LLM activity is traceable in Sentry.

## Changes
- Updated backend/src/business/ai/AiService.ts to create a child Sentry span around the OpenAI chat completion call.
- Added `gen_ai.request` span operation metadata with model information (`gen_ai.request.model`).
- Captured token usage attributes from OpenAI responses (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`) when available.
- Marked the AI span as `internal_error` on failure and ensured span completion in a `finally` block.
- Kept prompt/response content capture disabled (no prompt/output payload attributes recorded).

## Testing
- Ran formatter: `prettier --cache --write backend/src/business/ai/AiService.ts` (via Format tool).
- Attempted lint via `npm run lint -- src/business/ai/AiService.ts` but project script fails due ESLint CLI/config mismatch (`--ext` invalid with current ESLint).
- Attempted direct lint via `npx eslint src/business/ai/AiService.ts` but repository is missing flat config (`eslint.config.*`) for ESLint v9.
- Attempted type check via `npm run types`; failed because `tsc` is not available in the current environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4142638d-535a-4c29-9076-5fa98b6e5e2a)

Comment @datadog to request changes