### PR TITLE
Enable API Gateway access logs in production

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -24,6 +24,11 @@ provider:
           Action:
             - secretsmanager:GetSecretValue
           Resource: ${self:custom.datadog.apiKeySecretArn}
+  logs:
+    restApi:
+      accessLogging: true
+      format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","responseLength":"$context.responseLength","responseLatency":"$context.responseLatency","userAgent":"$context.identity.userAgent","requestTime":"$context.requestTime"}'
+      executionLogging: false
   environment:
     STAGE: ${sls:stage}
     DB_HOST: ${ssm:/${self:service}-${sls:stage}-db-host}


### PR DESCRIPTION
## Summary
- Adds `provider.logs.restApi` to `serverless.yml` to enable structured JSON access logging on the API Gateway stage
- Access logs include: request ID, IP, HTTP method, resource path, status, response length, latency, user agent, and timestamp
- Execution logging left off (verbose/expensive)
- Logs land in `/aws/api-gateway/fourtiesnyc-production`, ingested by the existing Datadog serverless plugin

## Verify after deploy
- [ ] Make a test request to `api.1940s.nyc`
- [ ] Confirm logs appear in CloudWatch at `/aws/api-gateway/fourtiesnyc-production`
- [ ] Confirm logs appear in Datadog

🤖 Generated with [Claude Code](https://claude.com/claude-code)