### PR TITLE
Set 30-day retention on API Gateway access log group

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -157,3 +157,10 @@ custom:
     addLayers: true
     exclude:
       - renderMerchPrintfiles
+resources:
+  Resources:
+    ApiGatewayAccessLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/api-gateway/${self:service}-${sls:stage}
+        RetentionInDays: 30


### PR DESCRIPTION
Codifies the 30-day retention policy already applied via CLI to `/aws/api-gateway/fourtiesnyc-production`, so it survives stack redeployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)