### PR TITLE
Approve Dependabot PRs before auto-merging

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,8 +15,21 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || (steps.metadata.outputs.dependency-type == 'indirect' && steps.metadata.outputs.update-type == 'version-update:semver-minor')}}
+      - name: Check if eligible for auto-merge
+        id: check
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.metadata.outputs.dependency-type == 'indirect' &&
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: echo "eligible=true" >> $GITHUB_OUTPUT
+      - name: Approve PR
+        if: steps.check.outputs.eligible == 'true'
+        uses: juliangruber/approve-pull-request-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.pull_request.number }}
+      - name: Enable auto-merge
+        if: steps.check.outputs.eligible == 'true'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## Summary

- Adds an approval step (`juliangruber/approve-pull-request-action@v2`) before `gh pr merge --auto` so Dependabot PRs can pass branch protection rules that require at least one approval
- Extracts the eligibility condition (patch updates, or indirect minor updates) into a single gate step to avoid duplication

## Test plan

- [ ] Merge this PR, then wait for or manually trigger a Dependabot patch-version PR
- [ ] Confirm the workflow run shows all three steps: **Check if eligible**, **Approve PR**, **Enable auto-merge**
- [ ] Confirm the Dependabot PR shows an approval from `github-actions[bot]` before it merges
- [ ] Confirm a Dependabot major-version PR does **not** get approved or auto-merged (gate step skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)