### PR TITLE
chore: enable react-router v7_startTransition future flag

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12434,7 +12434,6 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
       "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "react-router": "6.30.3"

--- a/frontend/src/screens/App/index.tsx
+++ b/frontend/src/screens/App/index.tsx
@@ -179,7 +179,7 @@ function ContextWrappers({
 export default function App(): JSX.Element {
   return (
     <ContextWrappers>
-      <BrowserRouter>
+      <BrowserRouter future={{ v7_startTransition: true }}>
         <DatadogRouteTracker />
         <Routes>
           {/* Routes with main layout (image viewer, announcements, modals) */}


### PR DESCRIPTION
Enable the `v7_startTransition` future flag on `<BrowserRouter>` as part of the React Router v5→v6→v7 migration.

Per https://reactrouter.com/7.12.0/upgrading/v6#v7_startTransition

No code changes needed — no `React.lazy` usage inside components.