### PR TITLE
chore: enable react-router v7_relativeSplatPath future flag

### DIFF
--- a/frontend/src/screens/App/index.tsx
+++ b/frontend/src/screens/App/index.tsx
@@ -179,7 +179,7 @@ function ContextWrappers({
 export default function App(): JSX.Element {
   return (
     <ContextWrappers>
-      <BrowserRouter>
+      <BrowserRouter future={{ v7_relativeSplatPath: true }}>
         <DatadogRouteTracker />
         <Routes>
           {/* Routes with main layout (image viewer, announcements, modals) */}


### PR DESCRIPTION
Enable the `v7_relativeSplatPath` future flag on `<BrowserRouter>` as part of the React Router v5→v6→v7 migration.

**No route splitting needed** — the app uses absolute paths for all Link components (e.g. `<Link to="/map">`, `<Link to="/stories">`), so splitting multi-segment splat routes is not required.

Per https://reactrouter.com/7.12.0/upgrading/v6#v7_relativesplatpath