### PR TITLE
chore: upgrade react-router from v6 to v7

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "react-dom": "^18.2.0",
         "react-modal": "^3.16.1",
         "react-number-format": "^5.3.1",
-        "react-router-dom": "^6.30.3",
+        "react-router": "^7.15.0",
         "react-transition-group": "^4.4.1",
         "react-virtualized-auto-sizer": "^1.0.7",
         "react-window": "^1.8.7",
@@ -2354,15 +2354,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -12415,35 +12406,38 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-themeable": {
@@ -13097,6 +13091,12 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^18.2.0",
     "react-modal": "^3.16.1",
     "react-number-format": "^5.3.1",
-    "react-router-dom": "^6.30.3",
+    "react-router": "^7.15.0",
     "react-transition-group": "^4.4.1",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.7",

--- a/frontend/src/screens/App/index.tsx
+++ b/frontend/src/screens/App/index.tsx
@@ -8,7 +8,7 @@ import {
   Routes,
   useLocation,
   useMatch,
-} from 'react-router-dom';
+} from 'react-router';
 import AnnouncementBanner from './screens/AnnouncementBanner';
 import MapPane from './screens/MapPane';
 import Shutdown from './screens/Shutdown';
@@ -179,9 +179,7 @@ function ContextWrappers({
 export default function App(): JSX.Element {
   return (
     <ContextWrappers>
-      <BrowserRouter
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-      >
+      <BrowserRouter>
         <DatadogRouteTracker />
         <Routes>
           {/* Routes with main layout (image viewer, announcements, modals) */}

--- a/frontend/src/screens/App/screens/Admin/AdminRoutes.tsx
+++ b/frontend/src/screens/App/screens/Admin/AdminRoutes.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import LoginPage from './screens/LoginPage';
 import ReviewMerch from './screens/ReviewMerch';
 import ReviewStories from './screens/ReviewStories';

--- a/frontend/src/screens/App/screens/Admin/screens/LoginPage.tsx
+++ b/frontend/src/screens/App/screens/Admin/screens/LoginPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import Button from 'shared/components/Button';
 import useAuthStore from 'shared/stores/AuthStore';
 
@@ -18,7 +18,7 @@ export default function LoginPage(): JSX.Element {
   // If authenticated, redirect to the page they were trying to access
   React.useEffect(() => {
     if (isAutheticated) {
-      navigate(from, { replace: true });
+      void navigate(from, { replace: true });
     } else {
       //automatically trigger login modal
       login(from);

--- a/frontend/src/screens/App/screens/Admin/shared/components/PrivateRoute.tsx
+++ b/frontend/src/screens/App/screens/Admin/shared/components/PrivateRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 
 import useAuthStore from 'shared/stores/AuthStore';
 

--- a/frontend/src/screens/App/screens/AllStories/index.tsx
+++ b/frontend/src/screens/App/screens/AllStories/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import classnames from 'classnames';
 
-import { Link } from 'react-router-dom';
-import { useLocation, useMatch } from 'react-router-dom';
+import { Link } from 'react-router';
+import { useLocation, useMatch } from 'react-router';
 import { Story } from 'screens/App/shared/types/Story';
 import Grid from 'shared/components/Grid';
 import StoryView from 'shared/components/Story';

--- a/frontend/src/screens/App/screens/CreditPurchaseModal/SuccessMessage.tsx
+++ b/frontend/src/screens/App/screens/CreditPurchaseModal/SuccessMessage.tsx
@@ -1,6 +1,6 @@
 import Modal from 'components/Modal';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import recordEvent from 'shared/utils/recordEvent';
 
 export default function ThankYou({
@@ -16,7 +16,7 @@ export default function ThankYou({
 
   React.useEffect(() => {
     // Remove query from url
-    navigate(
+    void navigate(
       { pathname: window.location.pathname, hash: window.location.hash },
       { replace: true }
     );

--- a/frontend/src/screens/App/screens/EditStory.tsx
+++ b/frontend/src/screens/App/screens/EditStory.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 
 import { useStoryDraftStore } from './SubmitStoryWizard';
 

--- a/frontend/src/screens/App/screens/FeatureFlags/index.tsx
+++ b/frontend/src/screens/App/screens/FeatureFlags/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import FeatureFlag from 'screens/App/shared/types/FeatureFlag';
 import useFeatureFlagsStore from 'screens/App/shared/stores/FeatureFlagsStore';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { lowerCase, upperFirst } from 'lodash';
 
 export default function FeatureFlags(): JSX.Element {

--- a/frontend/src/screens/App/screens/MapPane/components/MainMap/MapLibreMap.tsx
+++ b/frontend/src/screens/App/screens/MapPane/components/MainMap/MapLibreMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { NavigateFunction, useMatch, useNavigate } from 'react-router-dom';
+import { NavigateFunction, useMatch, useNavigate } from 'react-router';
 
 import classnames from 'classnames';
 import * as maplibregl from 'maplibre-gl';
@@ -51,7 +51,7 @@ class MapLibreMap
       if (!e || !e.features) return;
       const feature = e.features[0];
       const identifier = feature.properties?.photoIdentifier as string;
-      this.props.navigate({
+      void this.props.navigate({
         pathname: '/map/photo/' + identifier,
         hash: window.location.hash,
       });

--- a/frontend/src/screens/App/screens/MapPane/index.tsx
+++ b/frontend/src/screens/App/screens/MapPane/index.tsx
@@ -9,8 +9,8 @@ import { closest } from 'utils/photosApi';
 import { OverlayId } from './components/MainMap';
 import { MapInterface } from './components/MainMap/MapInterface';
 
-import { Link } from 'react-router-dom';
-import { useNavigate, NavigateFunction } from 'react-router-dom';
+import { Link } from 'react-router';
+import { useNavigate, NavigateFunction } from 'react-router';
 import stylesheet from './MapPane.less';
 import Geolocate from './components/Geolocate';
 import MainMap from './components/MainMap';
@@ -104,7 +104,7 @@ class MapPane extends React.Component<PropsWithNavigate, State> {
   }
 
   openPhoto(identifier: string): void {
-    this.props.navigate({
+    void this.props.navigate({
       pathname: '/map/photo/' + identifier,
       hash: window.location.hash,
     });

--- a/frontend/src/screens/App/screens/Merch/screens/Orders/index.tsx
+++ b/frontend/src/screens/App/screens/Merch/screens/Orders/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import absurd from 'shared/utils/absurd';
 import {
   MerchInternalVariant,

--- a/frontend/src/screens/App/screens/Outtakes/index.tsx
+++ b/frontend/src/screens/App/screens/Outtakes/index.tsx
@@ -4,8 +4,8 @@ import classnames from 'classnames';
 
 import { getOuttakeSummaries, PhotoSummary } from 'shared/utils/photosApi';
 
-import { Link, useNavigate } from 'react-router-dom';
-import { useMatch } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
+import { useMatch } from 'react-router';
 import Grid from 'shared/components/Grid';
 import Paginated from 'shared/types/Paginated';
 import { PHOTO_BASE } from 'shared/utils/apiConstants';
@@ -117,7 +117,7 @@ export default function Outtakes({
                 }}
                 onClick={() => {
                   // visibleImageIRef.current = i;
-                  navigate('/outtakes/photo/' + identifier);
+                  void navigate('/outtakes/photo/' + identifier);
                 }}
               />
             );

--- a/frontend/src/screens/App/screens/TipJar/ThankYou.tsx
+++ b/frontend/src/screens/App/screens/TipJar/ThankYou.tsx
@@ -1,7 +1,7 @@
 import Modal from 'components/Modal';
 import qs from 'qs';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import recordEvent from 'shared/utils/recordEvent';
 
 export default function ThankYou({
@@ -23,7 +23,7 @@ export default function ThankYou({
     window.localStorage.setItem('hasTipped', 'true');
 
     // Remove query from url
-    navigate(
+    void navigate(
       { pathname: window.location.pathname, hash: window.location.hash },
       { replace: true }
     );

--- a/frontend/src/screens/App/screens/ToteBag/index.tsx
+++ b/frontend/src/screens/App/screens/ToteBag/index.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import BagBack from './components/Back';
 import BagFront, { Color } from './components/Front';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import stylesheet from './ToteBag.less';
 
 export default function ToteBag(): JSX.Element {

--- a/frontend/src/screens/App/screens/ViewerPane/components/Alternates/index.tsx
+++ b/frontend/src/screens/App/screens/ViewerPane/components/Alternates/index.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { CSSTransition } from 'react-transition-group';
 import { PHOTO_BASE } from 'shared/utils/apiConstants';
 import { getAlternatePhotos, Photo } from 'shared/utils/photosApi';

--- a/frontend/src/screens/App/screens/ViewerPane/components/ImageButtons.tsx
+++ b/frontend/src/screens/App/screens/ViewerPane/components/ImageButtons.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { API_BASE } from 'utils/apiConstants';
 
 import Button, { ButtonStyledLink } from 'shared/components/Button';

--- a/frontend/src/screens/App/screens/ViewerPane/index.tsx
+++ b/frontend/src/screens/App/screens/ViewerPane/index.tsx
@@ -9,7 +9,7 @@ import {
   TransformComponent,
   TransformWrapper,
 } from '@jboolean/react-zoom-pan-pinch';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import Alternates from './components/Alternates';
 import ImageButtons from './components/ImageButtons';
 import * as ImageStack from './components/ImageStack';


### PR DESCRIPTION
## Summary
Upgrades `react-router-dom` v6 to `react-router` v7. All future flags were already enabled on master, so the upgrade is straightforward.

### Changes
- **Package**: Replaced `react-router-dom` with `react-router@^7.15.0`
- **Imports**: All imports updated from `from 'react-router-dom'` to `from 'react-router'`
- **Future flags removed**: `<BrowserRouter future={{...}}>` → `<BrowserRouter>` (v7 behavior is now default)
- **navigate() returns Promise in v7**: Added `void` prefix to 6 `navigate()` calls to satisfy `@typescript-eslint/no-floating-promises`

## Test plan
- [x] `npm run build` compiles clean (TypeScript + webpack)
- [x] `npm run lint:strict` passes with 0 errors and 0 warnings
- [ ] CI checks pass (lint, types, build, E2E)