### PR TITLE
Bound Lambda database connection pools

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -73,17 +73,28 @@ app.use(
   })
 );
 
-app.use(async (req, res, next) => {
+const initializeDatabase = async (
+  req: ExRequest,
+  res: ExResponse,
+  next: NextFunction
+) => {
   await createConnection();
   next();
-});
+};
 
+// These routes may use the database, but static/unknown API Gateway requests
+// should not create a TypeORM pool in a Lambda execution environment.
+app.use(
+  ['/geodata', '/stripe-webhooks', '/postmark-webhooks', '/printful-webhooks'],
+  initializeDatabase
+);
 app.use('/geodata', GeodataResource);
 app.use('/stripe-webhooks', StripeWebhooksResource);
 app.use('/postmark-webhooks', PostmarkWebhooksResource);
 app.use('/printful-webhooks', PrintfulWebhooksResource);
 
 // Tsoa
+app.use(initializeDatabase);
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
 RegisterRoutes(app);
 

--- a/backend/src/createConnection.ts
+++ b/backend/src/createConnection.ts
@@ -23,6 +23,14 @@ import User from './entities/User';
 
 // DB connection related env vars
 const { DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_DATABASE } = process.env;
+
+// Lambda can create many execution environments in response to a traffic spike.
+// Keep each environment's pool small so the database connection count scales
+// with concurrent work rather than with the driver's default pool size.
+const DB_POOL_MAX = Number(process.env.DB_POOL_MAX ?? 1);
+const DB_IDLE_TIMEOUT_MILLIS = Number(
+  process.env.DB_IDLE_TIMEOUT_MILLIS ?? 10000
+);
 // Force entity class metadata to be evaluated
 const ENTITIES = [
   AddressCorrection,
@@ -70,6 +78,10 @@ export const AppDataSource = new DataSource({
   logging: !!process.env.IS_OFFLINE,
   entities: ENTITIES,
   namingStrategy: new SnakeNamingStrategy(),
+  extra: {
+    max: DB_POOL_MAX,
+    idleTimeoutMillis: DB_IDLE_TIMEOUT_MILLIS,
+  },
 });
 
 export default async function createConnectionIfNotExists(): Promise<DataSource> {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"94636768-5140-4b33-a5b4-381333509627","source":"chat","resourceId":"278dd34a-c308-4b1d-b0ef-ffadf00efe67","workflowId":"43f3cc19-9fb6-4b12-ac67-be7b0e55bbc6","codeChangeId":"43f3cc19-9fb6-4b12-ac67-be7b0e55bbc6","sourceType":"bits_ai_sre"} -->
## Motivation/Summary

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/b2543e2d-9d92-496e-a398-3173d2268899)

A traffic spike caused Lambda execution environments to create TypeORM PostgreSQL pools at the driver's default size, increasing RDS sessions unnecessarily. This change bounds each pool and avoids initializing the database for the separately mounted webhook/geodata routes until they are actually reached.

## Changes
- Configure the TypeORM PostgreSQL pool with an explicit default maximum of one connection per Lambda environment and a 10-second idle timeout, with environment overrides.
- Move database initialization from the unconditional app middleware into database-backed route mounts and the TSOA API route boundary.

## Testing/Validation
- Prettier check passed after formatting `backend/src/app.ts` and `backend/src/createConnection.ts`.
- `git diff --check` passed.
- TypeScript validation could not run because backend dependencies are not installed (`tsc: not found`).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/278dd34a-c308-4b1d-b0ef-ffadf00efe67)

Comment @datadog to request changes