### PR TITLE
Limit Lambda database pool size

### DIFF
--- a/backend/src/createConnection.ts
+++ b/backend/src/createConnection.ts
@@ -68,6 +68,8 @@ export const AppDataSource = new DataSource({
   },
   synchronize: false,
   logging: !!process.env.IS_OFFLINE,
+  // Lambda processes one invocation at a time per execution environment.
+  poolSize: 1,
   entities: ENTITIES,
   namingStrategy: new SnakeNamingStrategy(),
 });

--- a/backend/src/createConnection.ts
+++ b/backend/src/createConnection.ts
@@ -69,7 +69,7 @@ export const AppDataSource = new DataSource({
   synchronize: false,
   logging: !!process.env.IS_OFFLINE,
   // Lambda processes one invocation at a time per execution environment.
-  poolSize: 1,
+  poolSize: 3,
   entities: ENTITIES,
   namingStrategy: new SnakeNamingStrategy(),
 });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ef8d1419-29f5-4866-8739-ea72101543df","source":"chat","resourceId":"263ff462-0e31-41f1-a3aa-2615b500dc3a","workflowId":"229d0611-2b79-4c07-b3f0-450d441eba34","codeChangeId":"229d0611-2b79-4c07-b3f0-450d441eba34","sourceType":"bits_ai_sre"} -->
## Summary

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/f51f4bfc-6de5-46ec-8036-e1c4b0c90c3d)

The Lambda-shared PostgreSQL DataSource could open the PostgreSQL driver's default pool for every concurrent execution environment, multiplying connections during traffic bursts. This change limits each environment to one connection to reduce connection pressure on the shared RDS instance.

## Changes
- Set `poolSize: 1` on `backend/src/createConnection.ts`.
- Keep the existing module-level DataSource reuse and all other connection behavior unchanged.

## Testing/Validation
- Reviewed the DataSource callers and Lambda entry points to confirm they share this configuration.
- `git diff --check` passed.
- ESLint could not run because dependencies are not installed and the environment lacks the repository's `jboolean` shared config.

## Impact
This bounds connections per warm Lambda execution environment while preserving database access; total connections can still scale with the number of Lambda environments.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/263ff462-0e31-41f1-a3aa-2615b500dc3a)

Comment @datadog to request changes