### PR TITLE
Reject non-Cloudflare requests at the photos CDN edge

### DIFF
--- a/.github/workflows/edge-pr.yml
+++ b/.github/workflows/edge-pr.yml
@@ -1,0 +1,48 @@
+name: edge-pr
+on:
+  pull_request:
+    paths:
+      - "edge/**"
+  schedule:
+    # Catch Cloudflare publishing a new range when nobody is touching this code
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+defaults:
+  run:
+    shell: bash
+    working-directory: edge
+jobs:
+  cloudflareIps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: npm ci
+      - name: Sync Cloudflare IP ranges
+        run: npm run sync-cloudflare-ips
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code -- cloudflareIpRanges.ts; then
+            echo "::error::Cloudflare's published IP ranges have changed. Run 'npm run sync-cloudflare-ips' in /edge, commit the result, and redeploy."
+            exit 1
+          fi
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: npm ci
+      - run: npm test
+  types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: npm ci
+      - run: npm run types

--- a/edge/cloudflareIpRanges.ts
+++ b/edge/cloudflareIpRanges.ts
@@ -1,0 +1,36 @@
+// GENERATED FILE — DO NOT EDIT BY HAND.
+// Run `npm run sync-cloudflare-ips` in /edge to refresh from
+// https://www.cloudflare.com/ips-v4 and https://www.cloudflare.com/ips-v6.
+
+export const CLOUDFLARE_IPV4_RANGES = [
+  "173.245.48.0/20",
+  "103.21.244.0/22",
+  "103.22.200.0/22",
+  "103.31.4.0/22",
+  "141.101.64.0/18",
+  "108.162.192.0/18",
+  "190.93.240.0/20",
+  "188.114.96.0/20",
+  "197.234.240.0/22",
+  "198.41.128.0/17",
+  "162.158.0.0/15",
+  "104.16.0.0/13",
+  "104.24.0.0/14",
+  "172.64.0.0/13",
+  "131.0.72.0/22",
+];
+
+export const CLOUDFLARE_IPV6_RANGES = [
+  "2400:cb00::/32",
+  "2606:4700::/32",
+  "2803:f800::/32",
+  "2405:b500::/32",
+  "2405:8100::/32",
+  "2a06:98c0::/29",
+  "2c0f:f248::/32",
+];
+
+export const CLOUDFLARE_RANGES = [
+  ...CLOUDFLARE_IPV4_RANGES,
+  ...CLOUDFLARE_IPV6_RANGES,
+];

--- a/edge/ipRangeMatcher.ts
+++ b/edge/ipRangeMatcher.ts
@@ -1,0 +1,132 @@
+// CIDR matching for IPv4 and IPv6. Addresses are normalized into 128-bit IPv6
+// space, with IPv4 mapped into ::ffff:0:0/96, so both families share one path.
+
+const IPV4_MAPPED_PREFIX = 0xffffn << 32n;
+
+function parseIpv4(address: string): bigint | null {
+  const octets = address.split(".");
+  if (octets.length !== 4) {
+    return null;
+  }
+
+  let value = 0n;
+  for (const octet of octets) {
+    if (!/^\d{1,3}$/.test(octet)) {
+      return null;
+    }
+    const parsed = Number(octet);
+    if (parsed > 255) {
+      return null;
+    }
+    value = (value << 8n) | BigInt(parsed);
+  }
+  return value;
+}
+
+function parseIpv6(address: string): bigint | null {
+  let text = address;
+
+  // Rewrite an embedded IPv4 tail (::ffff:104.16.0.1) as two hex groups.
+  const lastColon = text.lastIndexOf(":");
+  if (lastColon === -1) {
+    return null;
+  }
+  const tail = text.slice(lastColon + 1);
+  if (tail.includes(".")) {
+    const embedded = parseIpv4(tail);
+    if (embedded === null) {
+      return null;
+    }
+    text =
+      text.slice(0, lastColon + 1) +
+      (embedded >> 16n).toString(16) +
+      ":" +
+      (embedded & 0xffffn).toString(16);
+  }
+
+  const halves = text.split("::");
+  if (halves.length > 2) {
+    return null;
+  }
+  const leading = halves[0] ? halves[0].split(":") : [];
+  const trailing = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  const specified = leading.length + trailing.length;
+  if (halves.length === 2 ? specified > 8 : specified !== 8) {
+    return null;
+  }
+
+  const groups = [
+    ...leading,
+    ...(Array(8 - specified).fill("0") as string[]),
+    ...trailing,
+  ];
+
+  let value = 0n;
+  for (const group of groups) {
+    if (!/^[0-9a-f]{1,4}$/i.test(group)) {
+      return null;
+    }
+    value = (value << 16n) | BigInt(parseInt(group, 16));
+  }
+  return value;
+}
+
+/** Returns null if the address is malformed. */
+export function parseIp(address: string): bigint | null {
+  if (address.includes(":")) {
+    return parseIpv6(address);
+  }
+  const value = parseIpv4(address);
+  return value === null ? null : IPV4_MAPPED_PREFIX | value;
+}
+
+interface ParsedRange {
+  network: bigint;
+  mask: bigint;
+}
+
+function parseCidr(cidr: string): ParsedRange | null {
+  const [address, prefix] = cidr.split("/");
+  const value = parseIp(address);
+  if (value === null) {
+    return null;
+  }
+
+  let prefixLength = Number(prefix);
+  if (!Number.isInteger(prefixLength) || prefixLength < 0) {
+    return null;
+  }
+  // An IPv4 prefix is measured against the 32-bit address, so shift it past
+  // the ::ffff:0:0 mapping.
+  if (!address.includes(":")) {
+    prefixLength += 96;
+  }
+  if (prefixLength > 128) {
+    return null;
+  }
+
+  const mask =
+    ((1n << BigInt(prefixLength)) - 1n) << BigInt(128 - prefixLength);
+  return { network: value & mask, mask };
+}
+
+/** Throws on a malformed range so a typo fails at deploy time. */
+export function createIpRangeMatcher(
+  cidrs: string[]
+): (address: string) => boolean {
+  const ranges = cidrs.map((cidr) => {
+    const parsed = parseCidr(cidr);
+    if (!parsed) {
+      throw new Error(`Malformed CIDR range: ${cidr}`);
+    }
+    return parsed;
+  });
+
+  return (address: string): boolean => {
+    const value = parseIp(address);
+    if (value === null) {
+      return false;
+    }
+    return ranges.some((range) => (value & range.mask) === range.network);
+  };
+}

--- a/edge/package.json
+++ b/edge/package.json
@@ -11,7 +11,9 @@
     "serverless-plugin-typescript": "^2.1.5"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test",
+    "types": "tsc --noEmit --strict --target es2022 --module preserve --moduleResolution bundler --types node,aws-lambda *.ts",
+    "sync-cloudflare-ips": "node scripts/syncCloudflareIpRanges.mjs"
   },
   "author": "Julian boilen",
   "license": "ISC"

--- a/edge/scripts/syncCloudflareIpRanges.mjs
+++ b/edge/scripts/syncCloudflareIpRanges.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Regenerates cloudflareIpRanges.ts from Cloudflare's published lists. CI runs
+// this and fails if the working tree changed.
+
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const OUTPUT_PATH = fileURLToPath(
+  new URL("../cloudflareIpRanges.ts", import.meta.url)
+);
+
+const SOURCES = {
+  v4: "https://www.cloudflare.com/ips-v4",
+  v6: "https://www.cloudflare.com/ips-v6",
+};
+
+const HEADER = `// GENERATED FILE — DO NOT EDIT BY HAND.
+// Run \`npm run sync-cloudflare-ips\` in /edge to refresh from
+// ${SOURCES.v4} and ${SOURCES.v6}.
+`;
+
+async function fetchRanges(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${url} responded ${response.status}`);
+  }
+
+  const ranges = (await response.text())
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  // A truncated or redirected response would otherwise quietly shrink the allowlist.
+  if (ranges.length === 0) {
+    throw new Error(`${url} returned no ranges`);
+  }
+  for (const range of ranges) {
+    if (!/^[0-9a-f.:]+\/\d{1,3}$/i.test(range)) {
+      throw new Error(`${url} returned an unexpected entry: ${range}`);
+    }
+  }
+
+  return ranges;
+}
+
+function formatArray(name, ranges) {
+  const entries = ranges.map((range) => `  "${range}",`).join("\n");
+  return `export const ${name} = [\n${entries}\n];\n`;
+}
+
+const [v4, v6] = await Promise.all([
+  fetchRanges(SOURCES.v4),
+  fetchRanges(SOURCES.v6),
+]);
+
+const contents = [
+  HEADER,
+  formatArray("CLOUDFLARE_IPV4_RANGES", v4),
+  formatArray("CLOUDFLARE_IPV6_RANGES", v6),
+  `export const CLOUDFLARE_RANGES = [\n  ...CLOUDFLARE_IPV4_RANGES,\n  ...CLOUDFLARE_IPV6_RANGES,\n];\n`,
+].join("\n");
+
+await writeFile(OUTPUT_PATH, contents);
+
+console.log(
+  `Wrote ${v4.length} IPv4 and ${v6.length} IPv6 ranges to ${OUTPUT_PATH}`
+);

--- a/edge/serverless.yml
+++ b/edge/serverless.yml
@@ -24,3 +24,14 @@ functions:
         includeBody: false
         pathPattern: "*"
         stage: production
+  verifyCloudflareViewerRequest:
+    handler: verifyCloudflareViewerRequest.handler
+    tags:
+      Project: fourtiesnyc
+    events:
+      - preExistingCloudFront:
+        distributionId: E27U2N3WTCAYNV
+        eventType: viewer-request
+        includeBody: false
+        pathPattern: "*"
+        stage: production

--- a/edge/test/ipRangeMatcher.test.ts
+++ b/edge/test/ipRangeMatcher.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CLOUDFLARE_RANGES } from "../cloudflareIpRanges.ts";
+import { createIpRangeMatcher, parseIp } from "../ipRangeMatcher.ts";
+
+const isCloudflareIp = createIpRangeMatcher(CLOUDFLARE_RANGES);
+
+describe("parseIp", () => {
+  it("maps IPv4 into IPv6 space", () => {
+    assert.equal(parseIp("0.0.0.0"), 0xffff00000000n);
+    assert.equal(parseIp("255.255.255.255"), 0xffffffffffffn);
+  });
+
+  it("expands compressed IPv6", () => {
+    assert.equal(parseIp("::1"), 1n);
+    assert.equal(parseIp("2400:cb00::"), 0x2400cb00n << 96n);
+    assert.equal(parseIp("2400:cb00:0:0:0:0:0:0"), parseIp("2400:cb00::"));
+  });
+
+  it("reads IPv4-mapped IPv6 as the same address as its IPv4 form", () => {
+    assert.equal(parseIp("::ffff:104.16.0.1"), parseIp("104.16.0.1"));
+  });
+
+  it("rejects malformed addresses", () => {
+    for (const address of [
+      "",
+      "1.2.3",
+      "1.2.3.4.5",
+      "256.0.0.1",
+      "1.2.3.-1",
+      "abc",
+      "1::2::3",
+      "12345::",
+      "gggg::",
+      "1:2:3:4:5:6:7",
+    ]) {
+      assert.equal(parseIp(address), null, `expected null for "${address}"`);
+    }
+  });
+});
+
+describe("createIpRangeMatcher", () => {
+  it("matches addresses at both edges of a range", () => {
+    // 104.16.0.0/13 spans 104.16.0.0 - 104.23.255.255
+    assert.equal(isCloudflareIp("104.16.0.0"), true);
+    assert.equal(isCloudflareIp("104.23.255.255"), true);
+    assert.equal(isCloudflareIp("104.15.255.255"), false);
+    assert.equal(isCloudflareIp("104.24.0.0"), true); // covered by 104.24.0.0/14
+    assert.equal(isCloudflareIp("104.28.0.0"), false);
+  });
+
+  it("matches a /29 IPv6 range that is not hex-digit aligned", () => {
+    // 2a06:98c0::/29 spans 2a06:98c0:: - 2a06:98c7:ffff:...
+    assert.equal(isCloudflareIp("2a06:98c0::1"), true);
+    assert.equal(isCloudflareIp("2a06:98c7:ffff:ffff:ffff:ffff:ffff:ffff"), true);
+    assert.equal(isCloudflareIp("2a06:98c8::"), false);
+    assert.equal(isCloudflareIp("2a06:98bf:ffff::"), false);
+  });
+
+  it("does not confuse the IPv4 and IPv6 families", () => {
+    // 2400:cb00::/32 must not match anything in IPv4-mapped space
+    assert.equal(isCloudflareIp("36.0.203.0"), false);
+  });
+
+  it("rejects non-Cloudflare and malformed addresses", () => {
+    assert.equal(isCloudflareIp("8.8.8.8"), false);
+    assert.equal(isCloudflareIp("18.172.122.93"), false);
+    assert.equal(isCloudflareIp("not-an-ip"), false);
+    assert.equal(isCloudflareIp(""), false);
+  });
+
+  it("throws on a malformed range so typos fail at deploy time", () => {
+    assert.throws(() => createIpRangeMatcher(["10.0.0.0/33"]), /Malformed/);
+    assert.throws(() => createIpRangeMatcher(["10.0.0.0"]), /Malformed/);
+    assert.throws(() => createIpRangeMatcher(["nonsense/8"]), /Malformed/);
+  });
+});

--- a/edge/verifyCloudflareViewerRequest.ts
+++ b/edge/verifyCloudflareViewerRequest.ts
@@ -1,0 +1,60 @@
+import { CloudFrontRequestHandler } from "aws-lambda";
+import { CLOUDFLARE_RANGES } from "./cloudflareIpRanges";
+import { createIpRangeMatcher } from "./ipRangeMatcher";
+
+/**
+ * Rejects requests that did not come through Cloudflare, so nobody can bypass it
+ * by hitting the CloudFront domain directly.
+ *
+ * Runs on viewer-request, not origin-request: origin-request is skipped on a
+ * cache hit, so a direct requester would still be served cached objects.
+ */
+
+/**
+ * "log-only" logs what it would have rejected and lets the request through.
+ * Deploy in "log-only" and check the logs first — if this distribution is not
+ * yet fronted by Cloudflare, "enforce" takes every photo offline immediately.
+ *
+ * Lambda@Edge has no environment variables, so changing this needs a redeploy.
+ */
+const MODE: "enforce" | "log-only" = "log-only";
+
+const isCloudflareIp = createIpRangeMatcher(CLOUDFLARE_RANGES);
+
+export const handler: CloudFrontRequestHandler = async (event) => {
+  const request = event.Records[0].cf.request;
+
+  if (isCloudflareIp(request.clientIp)) {
+    return request;
+  }
+
+  console.warn("Request did not originate from Cloudflare", {
+    clientIp: request.clientIp,
+    uri: request.uri,
+    mode: MODE,
+  });
+
+  if (MODE === "log-only") {
+    return request;
+  }
+
+  return {
+    status: "403",
+    statusDescription: "Forbidden",
+    body: "Direct access is not permitted.",
+    headers: {
+      "cache-control": [
+        {
+          key: "Cache-Control",
+          value: "no-store",
+        },
+      ],
+      "content-type": [
+        {
+          key: "Content-Type",
+          value: "text/plain; charset=utf-8",
+        },
+      ],
+    },
+  };
+};

--- a/edge/verifyCloudflareViewerRequest.ts
+++ b/edge/verifyCloudflareViewerRequest.ts
@@ -2,21 +2,11 @@ import { CloudFrontRequestHandler } from "aws-lambda";
 import { CLOUDFLARE_RANGES } from "./cloudflareIpRanges";
 import { createIpRangeMatcher } from "./ipRangeMatcher";
 
-/**
- * Rejects requests that did not come through Cloudflare, so nobody can bypass it
- * by hitting the CloudFront domain directly.
- *
- * Runs on viewer-request, not origin-request: origin-request is skipped on a
- * cache hit, so a direct requester would still be served cached objects.
- */
+// Rejects requests that did not come through Cloudflare. On viewer-request
+// rather than origin-request, which is skipped on cache hits.
 
-/**
- * "log-only" logs what it would have rejected and lets the request through.
- * Deploy in "log-only" and check the logs first — if this distribution is not
- * yet fronted by Cloudflare, "enforce" takes every photo offline immediately.
- *
- * Lambda@Edge has no environment variables, so changing this needs a redeploy.
- */
+// "enforce" 403s. Don't flip it until this distribution is actually behind
+// Cloudflare — Lambda@Edge has no env vars, so it needs a redeploy either way.
 const MODE: "enforce" | "log-only" = "log-only";
 
 const isCloudflareIp = createIpRangeMatcher(CLOUDFLARE_RANGES);


### PR DESCRIPTION
Lambda@Edge viewer-request function on the photos distribution (`E27U2N3WTCAYNV`) that 403s requests whose client IP isn't in Cloudflare's published ranges — stops people bypassing Cloudflare via the CloudFront domain.

viewer-request, not origin-request: origin-request is skipped on cache hits.

**Ships in `log-only`.** DNS says `photos.1940s.nyc` isn't behind Cloudflare yet, so `enforce` today would 403 every photo. Flip `MODE` after the cutover.

- `ipRangeMatcher.ts` — dependency-free CIDR matching, IPv4 mapped into IPv6 space so both families share one path. 9 unit tests (range boundaries, the non-nibble-aligned `/29`, malformed input).
- `cloudflareIpRanges.ts` — generated by `scripts/syncCloudflareIpRanges.mjs`.
- `.github/workflows/edge-pr.yml` — `/edge` had no CI. Drift check (regenerate, fail if changed) on PRs + weekly cron, plus test/types jobs.

Cost at ~3M req/mo: $1.82. WAF would be $7.80 (same per-request rate + $6 fixed). CloudFront Functions would be $0.30 but its runtime has no BigInt, so the matcher would need a rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)