### PR TITLE
Trust 3 proxy hops, not 2

### DIFF
--- a/backend/src/api/PostmarkWebhooksResource.ts
+++ b/backend/src/api/PostmarkWebhooksResource.ts
@@ -18,7 +18,7 @@ if (!isProduction()) {
 
 router.use(
   '/',
-  ipfilter.IpFilter(POSTMARK_IPS, { mode: 'allow', trustProxy: 2 })
+  ipfilter.IpFilter(POSTMARK_IPS, { mode: 'allow', trustProxy: 3 })
 );
 
 router.post<

--- a/backend/src/api/StripeWebhooksResource.ts
+++ b/backend/src/api/StripeWebhooksResource.ts
@@ -40,7 +40,7 @@ if (!isProduction()) {
 // ipfilter does not use express's `trust proxy`, so repeat the hop count here
 router.use(
   '/',
-  ipfilter.IpFilter(STRIPE_IPS, { mode: 'allow', trustProxy: 2 })
+  ipfilter.IpFilter(STRIPE_IPS, { mode: 'allow', trustProxy: 3 })
 );
 
 router.post<'/', unknown, unknown, Stripe.Event, unknown>(

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -25,8 +25,8 @@ import PostmarkWebhooksResource from './api/PostmarkWebhooksResource';
 import PrintfulWebhooksResource from './api/PrintfulWebhooksResource';
 import StripeWebhooksResource from './api/StripeWebhooksResource';
 
-// Trust Cloudflare and API Gateway, in that order, when reading X-Forwarded-For
-app.set('trust proxy', 2);
+// Cloudflare -> CloudFront (edge-optimized API Gateway) -> API Gateway
+app.set('trust proxy', 3);
 
 Sentry.init({
   dsn: 'https://5c9a98d156614bac899b541f69d9b7f3@o4504630310600704.ingest.sentry.io/4504630315974657',


### PR DESCRIPTION
#1466 was off by one. `api.1940s.nyc` is an edge-optimized API Gateway domain, so there's an AWS-managed CloudFront between Cloudflare and API Gateway.

Verified against production after #1466 deployed: `express-ipfilter` reported `162.158.154.178` (Cloudflare) instead of the real client IP. `proxy-addr` sees `[cfEdge, cloudFrontIp, cfEdge, client]` — client is at index 3.

Webhooks are 403ing until this ships.