### PR TITLE
Fix renderMerchPrintfiles: bump chrome-aws-lambda layer to fix AL2023 chromium launch

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -46,7 +46,7 @@
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",
         "@hey-api/openapi-ts": "^0.64.1",
-        "@sparticuz/chromium": "^132.0.0",
+        "@sparticuz/chromium": "^149.0.0",
         "@tsoa/cli": "^4.1.3",
         "@types/aws-lambda": "^8.10.161",
         "@types/cookie-parser": "^1.4.3",
@@ -11502,17 +11502,16 @@
       }
     },
     "node_modules/@sparticuz/chromium": {
-      "version": "132.0.0",
-      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-132.0.0.tgz",
-      "integrity": "sha512-7SAhVa4nHAP7bxEhnMFuwV7KNDqAF4RVGZNwRhvyss8lJNT7Syi9nPwIPYvsHtjJ1S7Nx8OL8uqe9V3a/ED/Mg==",
+      "version": "149.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-149.0.0.tgz",
+      "integrity": "sha512-2NECBVKlUA9xIUXb4fT8OoGKdAJs+I2tNYscO8FwcxCKCWA7FmpPI0fdVxGJoIJglrFZYn+4YEJqChq4rdrxQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.9",
-        "tar-fs": "^3.0.8"
+        "tar-fs": "^3.1.2"
       },
       "engines": {
-        "node": ">= 16"
+        "node": "^22.17.0 || >=24.0.0"
       }
     },
     "node_modules/@sqltools/formatter": {
@@ -27499,9 +27498,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1045.0",
     "@hey-api/openapi-ts": "^0.64.1",
-    "@sparticuz/chromium": "^132.0.0",
+    "@sparticuz/chromium": "^149.0.0",
     "@tsoa/cli": "^4.1.3",
     "@types/aws-lambda": "^8.10.161",
     "@types/cookie-parser": "^1.4.3",

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -127,7 +127,12 @@ functions:
       - schedule: rate(5 minutes)
     timeout: 120
     layers:
-      - arn:aws:lambda:us-east-1:764866452798:layer:chrome-aws-lambda:50
+      # Provides @sparticuz/chromium at /opt/nodejs/node_modules - the actual
+      # runtime source of the module (it's a devDependency in package.json, used
+      # only for local typechecking; not bundled into the deployed zip). Pinned to
+      # a version whose bundled Chromium works on the Amazon Linux 2023 image this
+      # Lambda runtime uses. See https://github.com/shelfio/chrome-aws-lambda-layer
+      - arn:aws:lambda:us-east-1:764866452798:layer:chrome-aws-lambda:115
     memorySize: 2048
   registerPrintfulWebhooks:
     handler: registerPrintfulWebhooks.handler

--- a/backend/src/business/merch/renderToteBag.ts
+++ b/backend/src/business/merch/renderToteBag.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 
-import chromium from '@sparticuz/chromium';
 import puppeteer from 'puppeteer-core';
+import type SparticuzChromium from '@sparticuz/chromium';
 
 const IS_LOCAL = !!process.env.IS_LOCAL;
 const FRONTEND_BASE_URL = process.env.FRONTEND_BASE_URL as string;
@@ -13,6 +13,18 @@ const LOCAL_CHROMIUM_EXECUTABLE_PATH =
 // Move center to account for tote bag bottom
 const LAT_OFFSET = -0.0007;
 const ZOOM = 17;
+
+// @sparticuz/chromium ships as an ES module. TypeScript's CommonJS output
+// rewrites `await import(...)` into a synchronous require(), which Node
+// refuses for a not-yet-loaded ES module. Calling import() indirectly (via
+// `new Function`) hides it from that rewrite, so this is Node's real,
+// asynchronous import() rather than a disguised require().
+// eslint-disable-next-line @typescript-eslint/no-implied-eval -- not eval; forces a genuine dynamic import(), see comment above
+const importChromium = new Function(
+  'return import("@sparticuz/chromium")'
+) as () => Promise<{
+  default: typeof SparticuzChromium;
+}>;
 
 export default async function renderToteBag({
   lat,
@@ -27,13 +39,22 @@ export default async function renderToteBag({
   foregroundColor?: string;
   backgroundColor?: string;
 }): Promise<Buffer> {
+  const chromium = IS_LOCAL ? null : (await importChromium()).default;
+
   const browser = await puppeteer.launch({
-    args: IS_LOCAL ? puppeteer.defaultArgs() : chromium.args,
-    defaultViewport: chromium.defaultViewport,
-    executablePath: IS_LOCAL
-      ? LOCAL_CHROMIUM_EXECUTABLE_PATH
-      : await chromium.executablePath(),
-    headless: chromium.headless as 'shell' | boolean,
+    args:
+      IS_LOCAL || !chromium
+        ? puppeteer.defaultArgs()
+        : puppeteer.defaultArgs({
+            args: chromium.args,
+            headless: 'shell',
+          }),
+    defaultViewport: { width: 17 * 150, height: 33 * 150 },
+    executablePath:
+      IS_LOCAL || !chromium
+        ? LOCAL_CHROMIUM_EXECUTABLE_PATH
+        : await chromium.executablePath(),
+    headless: 'shell',
     acceptInsecureCerts: IS_LOCAL,
   });
   const page = await browser.newPage();


### PR DESCRIPTION
## What was broken

The `renderMerchPrintfiles` cron renders a printfile image for each merch item and moves it from `CUSTOMIZED` to `READY_FOR_FULFILLMENT`. It has been failing on every single run for months, so every item that reaches `CUSTOMIZED` gets stuck there permanently. Error:

```
Failed to launch the browser process!
/tmp/chromium: error while loading shared libraries: libnspr4.so: cannot open shared object file
```

## Why

The Lambda's `chrome-aws-lambda` layer is what actually supplies the Chromium binary at runtime (the copy in `package.json` is dev-only, used just for type-checking — it's never in the deployed code). The layer version we had bundled an old Chromium build with a known bug: it's missing shared libraries on the OS image (Amazon Linux 2023) our current Lambda runtime uses.

## The fix

- Bump the layer to a newer version that bundles a fixed Chromium build.
- Update `renderToteBag.ts` for that build's small API changes.
- The new build only ships as an ES module, which needs one small workaround to load correctly from our CommonJS build (explained in a code comment).

## How I verified it

Deployed to staging and invoked it directly several times — the browser now launches and starts rendering successfully, which it never did before. (One unrelated error remains in staging: a DNS lookup failure for a staging-only hostname that isn't provisioned. Doesn't apply to production, which uses the real domain.)

Also added a monitor on this function's error rate so a regression like this pages someone instead of failing silently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)