### PR TITLE
Surface headless page errors in renderToteBag

### DIFF
--- a/backend/src/business/merch/renderToteBag.ts
+++ b/backend/src/business/merch/renderToteBag.ts
@@ -59,6 +59,15 @@ export default async function renderToteBag({
   });
   const page = await browser.newPage();
   await page.setViewport({ width: 17 * 150, height: 33 * 150 });
+  // Surface errors from inside the rendered page - otherwise a JS error in
+  // the frontend (e.g. a WebGL/map failure) fails silently until the
+  // waitForSelector timeout below, with no indication of the real cause.
+  page.on('console', (msg) =>
+    console.log(`[render-tote-bag page console] ${msg.text()}`)
+  );
+  page.on('pageerror', (err) =>
+    console.error('[render-tote-bag page error]', err)
+  );
 
   const urlParams = new URLSearchParams();
   urlParams.append('noWelcome', 'true');


### PR DESCRIPTION
## Why

After the chromium launch fix (#1470), the render pipeline advanced to a new failure: Puppeteer times out waiting for `#render-content`. The same URL loads fine in a normal browser with `#render-content` present immediately, so this looks like something specific to the headless environment (most likely WebGL/swiftshader failing during map initialization, which would throw and unmount the whole render tree - there's no error boundary around the map component).

We currently have no visibility into JS errors happening inside the headless page, so this fails completely silently.

## What this does

Forwards the page's console messages and uncaught errors to our own logs, so the next failure shows the real cause in CloudWatch instead of just a generic timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)