### PR TITLE
Route renderMerchPrintfiles at Netlify directly, bypassing Cloudflare

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -134,6 +134,12 @@ functions:
       # Lambda runtime uses. See https://github.com/shelfio/chrome-aws-lambda-layer
       - arn:aws:lambda:us-east-1:764866452798:layer:chrome-aws-lambda:115
     memorySize: 2048
+    environment:
+      # Overrides the provider-level FRONTEND_BASE_URL for this function only.
+      # Requests go straight to Netlify instead of the public, Cloudflare-fronted
+      # domain: Cloudflare's Bot Fight Mode can't be exempted via rules on our
+      # plan, and it blocks this headless-Chrome render pipeline outright.
+      FRONTEND_BASE_URL: ${ssm:/${self:service}-${sls:stage}-render-frontend-base-url}
   registerPrintfulWebhooks:
     handler: registerPrintfulWebhooks.handler
     # Invoked manually

--- a/backend/src/business/merch/renderToteBag.ts
+++ b/backend/src/business/merch/renderToteBag.ts
@@ -60,8 +60,8 @@ export default async function renderToteBag({
   const page = await browser.newPage();
   await page.setViewport({ width: 17 * 150, height: 33 * 150 });
   // Surface errors from inside the rendered page - otherwise a JS error in
-  // the frontend (e.g. a WebGL/map failure) fails silently until the
-  // waitForSelector timeout below, with no indication of the real cause.
+  // the frontend fails silently until the waitForSelector timeout below,
+  // with no indication of the real cause.
   page.on('console', (msg) =>
     console.log(`[render-tote-bag page console] ${msg.text()}`)
   );


### PR DESCRIPTION
## What was broken

Cloudflare was added in front of the site yesterday. Its Bot Fight Mode (Free plan) started challenging this Lambda's headless-Chrome requests to `/render-merch/tote-bag` with a JS challenge page instead of serving the real app - so the render never found its target element and every invocation timed out. Bot Fight Mode can't be exempted via WAF/Security Rules on the Free plan, so no rule-based workaround was possible.

## The fix

This is a purely internal request - our own Lambda screenshotting our own frontend - so it doesn't need to go through the public, Cloudflare-fronted domain at all. This overrides `FRONTEND_BASE_URL` for just this one function so it hits Netlify's origin directly instead.

## Verified

Already deployed and confirmed working in production: two real items that were stuck rendered successfully and advanced all the way to `ADDED_TO_ORDER`. Nothing remains stuck in `CUSTOMIZED` or `READY_FOR_FULFILLMENT`.

Note: this PR captures in git what's already live (I deployed directly to unblock production while iterating). The `RENDER_BYPASS_SECRET`/Cloudflare-rule approach from an earlier attempt is fully removed here since it's no longer used - safe to delete that Security Rule and the `render-bypass-secret` SSM parameters whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)