### PR TITLE
Route admin auth checks at Netlify directly, bypassing Cloudflare

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -68,6 +68,8 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
+    environment:
+      INTERNAL_FRONTEND_BASE_URL: ${self:custom.directFrontendOrigin}
   convertImage:
     enabled: '"${sls:stage}" == "production"'
     handler: convertImage.handler
@@ -139,11 +141,15 @@ functions:
       # Requests go straight to Netlify instead of the public, Cloudflare-fronted
       # domain: Cloudflare's Bot Fight Mode can't be exempted via rules on our
       # plan, and it blocks this headless-Chrome render pipeline outright.
-      FRONTEND_BASE_URL: ${ssm:/${self:service}-${sls:stage}-render-frontend-base-url}
+      FRONTEND_BASE_URL: ${self:custom.directFrontendOrigin}
   registerPrintfulWebhooks:
     handler: registerPrintfulWebhooks.handler
     # Invoked manually
 custom:
+  # Direct Netlify origin, bypassing our Cloudflare proxy. For server-to-server
+  # calls Lambda makes to our own frontend, where Cloudflare's Bot Fight Mode
+  # (can't be exempted via rules on our plan) blocks automated requests.
+  directFrontendOrigin: ${ssm:/${self:service}-${sls:stage}-render-frontend-base-url}
   webpack:
     webpackConfig: "webpack.config.js"
   bucket: fourties-photos

--- a/backend/src/api/auth/authHandler.ts
+++ b/backend/src/api/auth/authHandler.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import * as Express from 'express';
 import { UserData } from 'gotrue-js';
 import { Unauthorized } from 'http-errors';
@@ -39,7 +40,23 @@ export async function expressAuthentication(
       }
 
       return user;
-    } catch {
+    } catch (err) {
+      // Log the real cause before collapsing it to a generic 401 - otherwise
+      // failures upstream (e.g. Netlify Identity itself down, or something
+      // between us and it returning a non-JSON response) are indistinguishable
+      // from an actually-invalid token.
+      if (axios.isAxiosError(err)) {
+        console.error(
+          'Netlify identity check failed',
+          err.response?.status,
+          err.response?.headers?.['content-type'],
+          typeof err.response?.data === 'string'
+            ? err.response.data.slice(0, 500)
+            : err.response?.data
+        );
+      } else {
+        console.error('Netlify identity check failed', err);
+      }
       throw new Unauthorized('Invalid token');
     }
 

--- a/backend/src/business/utils/getNetlifyUser.ts
+++ b/backend/src/business/utils/getNetlifyUser.ts
@@ -1,11 +1,18 @@
 import axios from 'axios';
 import { UserData } from 'gotrue-js';
 
+// Direct Netlify origin, bypassing our Cloudflare proxy. This is a
+// server-to-server call, and Cloudflare's Bot Fight Mode (can't be exempted
+// via rules on our plan) intermittently blocks non-browser requests from
+// Lambda to the public domain, which surfaced as spurious "Invalid token"
+// errors on admin routes.
+const NETLIFY_ORIGIN = process.env.INTERNAL_FRONTEND_BASE_URL as string;
+
 export default async function getNetfilyUser(
   authToken: string
 ): Promise<UserData> {
   const userResp = await axios.get<UserData>(
-    'https://1940s.nyc/.netlify/identity/user',
+    new URL('/.netlify/identity/user', NETLIFY_ORIGIN).toString(),
     {
       headers: {
         Authorization: `Bearer ${authToken}`,


### PR DESCRIPTION
## What was broken

Admin/moderator actions in the site (viewing the merch review queue, updating order state, etc.) were intermittently failing with an `Invalid token` error, even right after logging in.

## Why

Every admin API request is verified by calling Netlify Identity to check the user's login token. That check was calling our public site domain (`1940s.nyc`), which we put behind Cloudflare last week. Cloudflare's "Bot Fight Mode" — a bot-blocking feature that can't be turned off for specific traffic on our current plan — sometimes blocks these background server-to-server requests because they don't look like a real person browsing in a web page. When that happens, the token check fails and the admin gets logged out with a confusing "Invalid token" error, even though their login is fine.

This is the same root cause we already fixed last week for the tote bag print image renderer, just showing up in a second place we hadn't updated yet.

## The fix

The token-check request now goes straight to Netlify's own servers instead of routing through `1940s.nyc` / Cloudflare, the same fix already applied to the tote bag renderer. This avoids Cloudflare's bot blocking entirely for this internal request, since it was never meant to go through the public-facing proxy anyway.

We also improved logging: previously, any failure in the token check was collapsed into the same generic "Invalid token" message with no detail. Now the real underlying error is logged, so if something like this happens again we'll be able to see exactly what went wrong instead of guessing.

## Verification

- Typecheck and lint pass.
- `serverless package` succeeds, and the resolved environment variable was confirmed in the packaged CloudFormation template to point at Netlify's direct domain rather than `1940s.nyc`.