### PR TITLE
Generalize the Cloudflare bypass instead of patching domains one at a time

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -41,6 +41,8 @@ provider:
     POSTMARK_TOKEN: ${ssm:/${self:service}-${sls:stage}-postmark-token}
     POSTMARK_SANDBOX_TOKEN: ${ssm:/${self:service}-${sls:stage}-postmark-sandbox-token}
     FRONTEND_BASE_URL: ${ssm:/${self:service}-${sls:stage}-frontend-base-url}
+    # See src/business/utils/cloudflareOrigins.ts
+    CLOUDFLARE_BYPASS_ORIGINS: ${ssm:/${self:service}-${sls:stage}-cloudflare-bypass-origins}
     JWT_SECRET: ${ssm:/${self:service}-${sls:stage}-jwt-secret}
     MODERATORS_TO_EMAIL: ${ssm:/${self:service}-${sls:stage}-moderators-to-email}
     MERCH_REVIEWER_EMAILS: ${ssm:/${self:service}-${sls:stage}-merch-reviewer-emails}
@@ -68,8 +70,6 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
-    environment:
-      INTERNAL_FRONTEND_BASE_URL: ${self:custom.directFrontendOrigin}
   convertImage:
     enabled: '"${sls:stage}" == "production"'
     handler: convertImage.handler
@@ -136,20 +136,10 @@ functions:
       # Lambda runtime uses. See https://github.com/shelfio/chrome-aws-lambda-layer
       - arn:aws:lambda:us-east-1:764866452798:layer:chrome-aws-lambda:115
     memorySize: 2048
-    environment:
-      # Overrides the provider-level FRONTEND_BASE_URL for this function only.
-      # Requests go straight to Netlify instead of the public, Cloudflare-fronted
-      # domain: Cloudflare's Bot Fight Mode can't be exempted via rules on our
-      # plan, and it blocks this headless-Chrome render pipeline outright.
-      FRONTEND_BASE_URL: ${self:custom.directFrontendOrigin}
   registerPrintfulWebhooks:
     handler: registerPrintfulWebhooks.handler
     # Invoked manually
 custom:
-  # Direct Netlify origin, bypassing our Cloudflare proxy. For server-to-server
-  # calls Lambda makes to our own frontend, where Cloudflare's Bot Fight Mode
-  # (can't be exempted via rules on our plan) blocks automated requests.
-  directFrontendOrigin: ${ssm:/${self:service}-${sls:stage}-render-frontend-base-url}
   webpack:
     webpackConfig: "webpack.config.js"
   bucket: fourties-photos

--- a/backend/src/api/auth/authHandler.ts
+++ b/backend/src/api/auth/authHandler.ts
@@ -41,10 +41,8 @@ export async function expressAuthentication(
 
       return user;
     } catch (err) {
-      // Log the real cause before collapsing it to a generic 401 - otherwise
-      // failures upstream (e.g. Netlify Identity itself down, or something
-      // between us and it returning a non-JSON response) are indistinguishable
-      // from an actually-invalid token.
+      // Log the real cause - otherwise it's indistinguishable from an
+      // actually-invalid token.
       if (axios.isAxiosError(err)) {
         console.error(
           'Netlify identity check failed',

--- a/backend/src/business/merch/renderToteBag.ts
+++ b/backend/src/business/merch/renderToteBag.ts
@@ -2,6 +2,7 @@
 
 import puppeteer from 'puppeteer-core';
 import type SparticuzChromium from '@sparticuz/chromium';
+import { bypassCloudflare } from '../utils/cloudflareOrigins';
 
 const IS_LOCAL = !!process.env.IS_LOCAL;
 const FRONTEND_BASE_URL = process.env.FRONTEND_BASE_URL as string;
@@ -68,6 +69,16 @@ export default async function renderToteBag({
   page.on('pageerror', (err) =>
     console.error('[render-tote-bag page error]', err)
   );
+
+  // Reroute the page (and everything it loads - map tiles, sprites, fonts,
+  // etc.) around Cloudflare. See cloudflareOrigins.ts for why.
+  await page.setRequestInterception(true);
+  page.on('request', (req) => {
+    const target = bypassCloudflare(req.url());
+    void (target === req.url()
+      ? req.continue()
+      : req.continue({ url: target }));
+  });
 
   const urlParams = new URLSearchParams();
   urlParams.append('noWelcome', 'true');

--- a/backend/src/business/utils/cloudflareOrigins.ts
+++ b/backend/src/business/utils/cloudflareOrigins.ts
@@ -1,0 +1,29 @@
+// Cloudflare's Bot Fight Mode blocks our own automated requests (headless
+// Chrome, server-to-server calls) to our *.1940s.nyc domains, and can't be
+// exempted via rules on our plan. This routes those requests directly to
+// the real origin instead. The hostname -> origin map is in SSM
+// (CLOUDFLARE_BYPASS_ORIGINS), not here, so it's not published in the repo.
+function loadDirectOrigins(): Record<string, string> {
+  const raw = process.env.CLOUDFLARE_BYPASS_ORIGINS;
+  if (!raw) {
+    return {};
+  }
+  return JSON.parse(raw) as Record<string, string>;
+}
+
+const DIRECT_ORIGINS = loadDirectOrigins();
+
+// Rewrites a URL to its direct origin if its host is in the map, otherwise
+// returns it unchanged.
+export function bypassCloudflare(url: string): string {
+  const parsed = new URL(url);
+  const direct = DIRECT_ORIGINS[parsed.hostname];
+  if (!direct) {
+    return url;
+  }
+
+  const directOrigin = new URL(direct);
+  parsed.protocol = directOrigin.protocol;
+  parsed.host = directOrigin.host;
+  return parsed.toString();
+}

--- a/backend/src/business/utils/getNetlifyUser.ts
+++ b/backend/src/business/utils/getNetlifyUser.ts
@@ -1,18 +1,12 @@
 import axios from 'axios';
 import { UserData } from 'gotrue-js';
-
-// Direct Netlify origin, bypassing our Cloudflare proxy. This is a
-// server-to-server call, and Cloudflare's Bot Fight Mode (can't be exempted
-// via rules on our plan) intermittently blocks non-browser requests from
-// Lambda to the public domain, which surfaced as spurious "Invalid token"
-// errors on admin routes.
-const NETLIFY_ORIGIN = process.env.INTERNAL_FRONTEND_BASE_URL as string;
+import { bypassCloudflare } from './cloudflareOrigins';
 
 export default async function getNetfilyUser(
   authToken: string
 ): Promise<UserData> {
   const userResp = await axios.get<UserData>(
-    new URL('/.netlify/identity/user', NETLIFY_ORIGIN).toString(),
+    bypassCloudflare('https://1940s.nyc/.netlify/identity/user'),
     {
       headers: {
         Authorization: `Bearer ${authToken}`,


### PR DESCRIPTION
Tote bag print images had blank maps. The map tiles load from `maptiles.1940s.nyc`, a domain that's Cloudflare-proxied like the rest of the site, and hit the same bot-blocking issue that already broke page loading and admin login — just via a domain neither earlier fix covered.

Rather than patch this domain too, this replaces both prior one-off fixes with one general mechanism: a list of "domain -> its real address" in AWS Parameter Store, and a helper that reroutes any matching request around Cloudflare. The print-renderer now applies this to everything the page loads, not just the page itself, so new domains just need adding to the list, not a code change.

Verified: typecheck, lint, and `serverless package` all pass.