### PR TITLE
Send Printful a printfile URL that bypasses Cloudflare, and fail on empty placements

### DIFF
--- a/backend/src/business/merch/PrintfulItemBuildService.ts
+++ b/backend/src/business/merch/PrintfulItemBuildService.ts
@@ -1,6 +1,6 @@
 import MerchInternalVariant from '../../enum/MerchInternalVariant';
 import absurd from '../utils/absurd';
-import { getPrintfileUrl } from '../utils/printfileUtils';
+import { getPrintfileDirectUrl } from '../utils/printfileUtils';
 import { CatalogItem as PrintfulCatalogItem } from '../utils/printfulApi';
 
 const INTERNAL_VARIANT_TO_PRINTFUL_VARIANT: Record<
@@ -30,7 +30,7 @@ export function makePrintfulItem(
             layers: [
               {
                 type: 'file',
-                url: getPrintfileUrl(customMerchItemId),
+                url: getPrintfileDirectUrl(customMerchItemId),
               },
             ],
           },

--- a/backend/src/business/merch/PrintfulItemBuildService.ts
+++ b/backend/src/business/merch/PrintfulItemBuildService.ts
@@ -10,10 +10,10 @@ const INTERNAL_VARIANT_TO_PRINTFUL_VARIANT: Record<
   [MerchInternalVariant.TOTE_BAG_SMALL]: 4533, // Product 84
 };
 
-export async function makePrintfulItem(
+export function makePrintfulItem(
   customMerchItemId: number,
   internalVariant: MerchInternalVariant
-): Promise<PrintfulCatalogItem> {
+): PrintfulCatalogItem {
   const printfulVariantId =
     INTERNAL_VARIANT_TO_PRINTFUL_VARIANT[internalVariant];
   switch (internalVariant) {
@@ -30,7 +30,7 @@ export async function makePrintfulItem(
             layers: [
               {
                 type: 'file',
-                url: await getPrintfileUrl(customMerchItemId, false),
+                url: getPrintfileUrl(customMerchItemId),
               },
             ],
           },

--- a/backend/src/business/merch/PrintfulService.ts
+++ b/backend/src/business/merch/PrintfulService.ts
@@ -83,7 +83,6 @@ export async function addItemToOrder(item: MerchOrderItem): Promise<void> {
     );
   }
 
-  // Created item is the whole response body, not nested under a second .data
   const createdItem = createdResp.data as unknown as {
     placements?: Array<{ placement: string }>;
   };

--- a/backend/src/business/merch/PrintfulService.ts
+++ b/backend/src/business/merch/PrintfulService.ts
@@ -68,12 +68,30 @@ export async function addItemToOrder(item: MerchOrderItem): Promise<void> {
     });
   }
 
-  await createItemByOrderId({
+  const createdResp = await createItemByOrderId({
     path: {
       order_id: printfulOrderId,
     },
-    body: await makePrintfulItem(item.id, item.internalVariant),
+    body: makePrintfulItem(item.id, item.internalVariant),
   });
+
+  if (createdResp.error) {
+    throw new Error(
+      `Printful API returned error creating item ${
+        item.id
+      } in order ${printfulOrderId}: ${JSON.stringify(createdResp.error)}`
+    );
+  }
+
+  // Created item is the whole response body, not nested under a second .data
+  const createdItem = createdResp.data as unknown as {
+    placements?: Array<{ placement: string }>;
+  };
+  if (!createdItem?.placements?.length) {
+    throw new Error(
+      `Printful created item ${item.id} in order ${printfulOrderId} but the placement was empty/not set. This means the printfile image could not be fetched. Refusing to continue.`
+    );
+  }
 }
 
 export async function submitOrderForFulfillment(

--- a/backend/src/business/utils/printfileUtils.ts
+++ b/backend/src/business/utils/printfileUtils.ts
@@ -1,9 +1,5 @@
-import {
-  GetObjectCommand,
-  PutObjectCommand,
-  S3Client,
-} from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { bypassCloudflare } from './cloudflareOrigins';
 import isProduction from './isProduction';
 
 const s3 = new S3Client();
@@ -25,24 +21,13 @@ export async function uploadPrintfile(
       Key: destinationKey,
       Body: buffer,
       ContentType: 'image/png',
+      CacheControl: 'no-cache',
     })
   );
 }
 
-export async function getPrintfileUrl(
-  customMerchItemId: number,
-  signedUrl = true
-): Promise<string> {
+export function getPrintfileUrl(customMerchItemId: number): string {
   const destinationKey = getPrintfileKey(customMerchItemId);
 
-  const command = new GetObjectCommand({
-    Bucket: 'fourties-photos',
-    Key: destinationKey,
-  });
-
-  if (signedUrl) {
-    return await getSignedUrl(s3, command, { expiresIn: 120 });
-  }
-
-  return `https://photos.1940s.nyc/${destinationKey}`;
+  return bypassCloudflare(`https://photos.1940s.nyc/${destinationKey}`);
 }

--- a/backend/src/business/utils/printfileUtils.ts
+++ b/backend/src/business/utils/printfileUtils.ts
@@ -1,4 +1,9 @@
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { bypassCloudflare } from './cloudflareOrigins';
 import isProduction from './isProduction';
 
@@ -26,8 +31,22 @@ export async function uploadPrintfile(
   );
 }
 
-export function getPrintfileUrl(customMerchItemId: number): string {
-  const destinationKey = getPrintfileKey(customMerchItemId);
+// Signed S3 URL for admin review.
+export async function getPrintfileUrl(
+  customMerchItemId: number
+): Promise<string> {
+  const command = new GetObjectCommand({
+    Bucket: 'fourties-photos',
+    Key: getPrintfileKey(customMerchItemId),
+  });
 
-  return bypassCloudflare(`https://photos.1940s.nyc/${destinationKey}`);
+  return await getSignedUrl(s3, command, { expiresIn: 120 });
+}
+
+// Direct CloudFront URL (bypassing Cloudflare) for Printful's server fetch,
+// which does a HEAD check before the GET (signed URLs can't support that).
+export function getPrintfileDirectUrl(customMerchItemId: number): string {
+  return bypassCloudflare(
+    `https://photos.1940s.nyc/${getPrintfileKey(customMerchItemId)}`
+  );
 }


### PR DESCRIPTION
Printful fetches each printfile image from the URL we provide. Those URLs went through `photos.1940s.nyc`, which like the rest of our site is proxied through Cloudflare, and its Bot Fight Mode blocked Printful's image fetch — the same problem that already hit page loading, admin login checks, and map tiles. This time it was worse because there was no error: Printful just silently dropped the design placement, and the item was added to the order with no print on the tote bag.

Three fixes in this PR:

1. **Bypass Cloudflare for the printfile URL** — use `bypassCloudflare()` so the URL points at the CloudFront distribution directly instead of `photos.1940s.nyc`.

2. **Cache control** — set `Cache-Control: no-cache` when uploading printfiles, so CloudFront revalidates on each fetch if the image is overwritten by a re-render.

3. **Hard error on empty placements** — the `addItemToOrder` function now checks the Printful API response for both errors and empty placement arrays, and throws if either is found. Previously the API could silently drop a design and we'd never know.

Verified: both items (43, 44) in production now have correct printfile URLs pointing at the direct CloudFront domain.