### PR TITLE
Remove colorization free trial

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -107,7 +107,7 @@ Automatic moderation was considered but most of the rejected stories are not spa
 
 For a seamless user experience and to reduce costs, a custom authentication system was built instead of using a third party service like Auth0.
 
-For any route tagged with `@Security('user-token')`, a user is created if one does not exist. The user is then considered logged in immediately without any information and is considered anonymous. Later, the user can provide, and optionally verify an email address. Specific features can check for verified email addresses if that level of security is needed. Corrections to geocodes, for example, require a verified email address. Colorization, however, can be done by anonymous users, allowing a limited "free trial" experience.
+For any route tagged with `@Security('user-token')`, a user is created if one does not exist. The user is then considered logged in immediately without any information and is considered anonymous. Later, the user can provide, and optionally verify an email address. Specific features can check for verified email addresses if that level of security is needed. Corrections to geocodes, for example, require a verified email address. Colorization, however, can be done by anonymous users, as long as they have a positive credit balance.
 
 **Log-in process**: The user supplies an email address: if an account exists the user is sent a magic link to log in, or the email is associated with the current possibly anonymous account they are logged in with. Magic links are JWT tokens.
 
@@ -115,7 +115,7 @@ Notably, **Stories** are not connected to Users because Stories were built first
 
 ### Credit ledgering
 
-Users can purchase "Color tokens" to colorize images. This is managed via the Ledger system, which is just a ledger of credits issued and images colorized. Users can go negative as we allow one free colorization per day as a trial.
+Users can purchase "Color tokens" to colorize images. This is managed via the Ledger system, which is just a ledger of credits issued and images colorized. Each colorization requires a positive balance; there is no free trial. Some users may still have a negative balance left over from before the free trial was removed, which `grantCredits` forgives via an amnesty when they next buy credits.
 
 `LedgerService.withMeteredUsage` is a wrapper to wrap code that requires and consumes credits.
 

--- a/backend/src/api/ColorizationController.ts
+++ b/backend/src/api/ColorizationController.ts
@@ -28,7 +28,7 @@ const COLOR_CREDIT_PRODUCT_ID = isProduction()
   ? 'prod_OCXuxXcQOP3N4j'
   : 'prod_OCE62CeqBcpuxW';
 
-const MIN_QUANTITY = 20;
+const MIN_QUANTITY = 10;
 const MAX_QUANTITY = 2000;
 
 @Route('colorization')

--- a/backend/src/business/ledger/LedgerService.ts
+++ b/backend/src/business/ledger/LedgerService.ts
@@ -1,13 +1,8 @@
 import { TooManyRequests } from 'http-errors';
-import { MoreThan, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { AppDataSource } from '../../createConnection';
 import LedgerEntry from '../../entities/LedgerEntry';
 import LedgerEntryType from '../../enum/LedgerEntryType';
-
-const RATE_LIMIT_LOOKBACK = 24 * 60 * 60 * 1000; // 24 hours
-
-// We allow this much usage in the lookback window
-const MAX_LOOKBACK_USAGES = 1;
 
 const SINGLE_PHOTO_USAGE_AMOUNT_POSITIVE = 1;
 
@@ -42,23 +37,6 @@ async function hasEnoughBalance(
   return balance >= amountToConsume;
 }
 
-async function isRateLimitExceeded(
-  userId: number,
-  ledgerRepository: Repository<LedgerEntry>
-): Promise<boolean> {
-  const { recentUsageSum } = (await ledgerRepository
-    .createQueryBuilder('entry')
-    .select('SUM(-entry.amount)', 'recentUsageSum')
-    .where({
-      userId,
-      createdAt: MoreThan(new Date(Date.now() - RATE_LIMIT_LOOKBACK)),
-      type: LedgerEntryType.USAGE, // <- only looking at usages, not balance
-    })
-    .getRawOne<{ recentUsageSum: number }>()) ?? { recentUsageSum: 0 };
-
-  return recentUsageSum >= MAX_LOOKBACK_USAGES;
-}
-
 export class UsageCapError extends TooManyRequests {
   constructor() {
     super('Usage cap exceeded');
@@ -82,14 +60,12 @@ export async function withMeteredUsage<R>(
     const ledgerRepository =
       transactionalEntityManager.getRepository(LedgerEntry);
 
-    // Must have not exceeded the rate limit (regardless of balance) or have lifetime balance
-    const isAllowed =
-      !(await isRateLimitExceeded(userId, ledgerRepository)) ||
-      (await hasEnoughBalance(
-        userId,
-        SINGLE_PHOTO_USAGE_AMOUNT_POSITIVE,
-        ledgerRepository
-      ));
+    // Must have enough balance to cover the usage
+    const isAllowed = await hasEnoughBalance(
+      userId,
+      SINGLE_PHOTO_USAGE_AMOUNT_POSITIVE,
+      ledgerRepository
+    );
 
     if (!isAllowed) {
       throw new UsageCapError();
@@ -121,7 +97,7 @@ export async function grantCredits(
 
   let creditsToGrant = quantity;
 
-  // They may have gone negative from free daily usage, so we give them amnesty
+  // They may have a negative balance from before the free trial was removed, so we give them amnesty
   if (giveAmnesty) {
     creditsToGrant += amnesty;
   }

--- a/frontend/src/screens/App/screens/CreditPurchaseModal/index.tsx
+++ b/frontend/src/screens/App/screens/CreditPurchaseModal/index.tsx
@@ -9,9 +9,9 @@ import { NumericFormat } from 'react-number-format';
 import PhotoAsideModal from '../PhotoAsideModal';
 import carouselImages from './carouselImages';
 
+import LoginForm from 'shared/components/LoginForm';
 import useLoginStore from '../../../../shared/stores/LoginStore';
 import stylesheet from './CreditPurchaseModal.less';
-import LoginForm from 'shared/components/LoginForm';
 
 export default function CreditPurchaseModal(): JSX.Element {
   const {
@@ -49,7 +49,7 @@ export default function CreditPurchaseModal(): JSX.Element {
           <p>
             Colorize photos using the best AI colorization model available. A
             small fee is required to cover the costs of the model. Purchase
-            tokens to keep exploring in color and support the site.
+            tokens to explore in color and support the site.
           </p>
 
           <p className={stylesheet.finePrint}>

--- a/frontend/src/screens/App/screens/CreditPurchaseModal/index.tsx
+++ b/frontend/src/screens/App/screens/CreditPurchaseModal/index.tsx
@@ -47,10 +47,9 @@ export default function CreditPurchaseModal(): JSX.Element {
 
         <div>
           <p>
-            Enjoy one free colorized photo per day using the best AI
-            colorization model available. After that, a small fee is required to
-            cover the costs of the model. Purchase tokens to keep exploring in
-            color and support the site.
+            Colorize photos using the best AI colorization model available. A
+            small fee is required to cover the costs of the model. Purchase
+            tokens to keep exploring in color and support the site.
           </p>
 
           <p className={stylesheet.finePrint}>

--- a/frontend/src/screens/App/screens/CreditPurchaseModal/index.tsx
+++ b/frontend/src/screens/App/screens/CreditPurchaseModal/index.tsx
@@ -43,7 +43,7 @@ export default function CreditPurchaseModal(): JSX.Element {
       }}
     >
       <div data-testid="credit-purchase-modal">
-        <h1>Continue exploring in color</h1>
+        <h1>Explore in color</h1>
 
         <div>
           <p>

--- a/frontend/src/screens/App/screens/CreditPurchaseModal/stores/CreditPurchaseStore.ts
+++ b/frontend/src/screens/App/screens/CreditPurchaseModal/stores/CreditPurchaseStore.ts
@@ -4,7 +4,7 @@ import create from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import useLoginStore from '../../../../../shared/stores/LoginStore';
 
-const PRESET_QUANTITIES = [50, 100, 200];
+const PRESET_QUANTITIES = [20, 50, 100, 200];
 
 interface State {
   isOpen: boolean;
@@ -27,7 +27,7 @@ const useCreditPurchaseModalStore = create(
   immer<State & Actions>((set, get) => ({
     isOpen: false,
     quantityOptions: PRESET_QUANTITIES,
-    selectedQuantity: PRESET_QUANTITIES[1],
+    selectedQuantity: 100,
     errorMessage: null,
     isCheckingOut: false,
     isFollowMagicLinkMessageVisible: false,


### PR DESCRIPTION
Removes the free colorization trial. 

I ran an analysis and realized this is constantly losing money, about $50 to $80 a month. With the recent traffic spike costs are surging and conversion is only around 2%. 
While it's a fun feature I want to offer to the most people, it no longer makes sense. 