### PR TITLE
Add loading, empty, and error states to Review Stories

### DIFF
--- a/frontend/src/screens/App/screens/Admin/screens/ReviewStories/index.tsx
+++ b/frontend/src/screens/App/screens/Admin/screens/ReviewStories/index.tsx
@@ -101,6 +101,16 @@ export default function ReviewStories(): JSX.Element {
         </ul>
       </details>
 
+      {reviewStoriesStore.isLoading ? <p>Loading&hellip;</p> : null}
+
+      {reviewStoriesStore.error ? <p>Failed to load stories. </p> : null}
+
+      {!reviewStoriesStore.isLoading &&
+      !reviewStoriesStore.error &&
+      reviewStoriesStore.stories.length === 0 ? (
+        <p>No stories to review.</p>
+      ) : null}
+
       <div className={stylesheet.stories}>
         {reviewStoriesStore.stories.map((story) => (
           <React.Fragment key={story.id}>

--- a/frontend/src/screens/App/screens/Admin/screens/ReviewStories/index.tsx
+++ b/frontend/src/screens/App/screens/Admin/screens/ReviewStories/index.tsx
@@ -103,9 +103,7 @@ export default function ReviewStories(): JSX.Element {
 
       {reviewStoriesStore.isLoading ? <p>Loading&hellip;</p> : null}
 
-      {reviewStoriesStore.error ? (
-        <p>Failed to load stories. Please try refreshing the page.</p>
-      ) : null}
+      {reviewStoriesStore.error ? <p>Failed to load stories. </p> : null}
 
       {!reviewStoriesStore.isLoading &&
       !reviewStoriesStore.error &&

--- a/frontend/src/screens/App/screens/Admin/screens/ReviewStories/index.tsx
+++ b/frontend/src/screens/App/screens/Admin/screens/ReviewStories/index.tsx
@@ -103,7 +103,9 @@ export default function ReviewStories(): JSX.Element {
 
       {reviewStoriesStore.isLoading ? <p>Loading&hellip;</p> : null}
 
-      {reviewStoriesStore.error ? <p>Failed to load stories. </p> : null}
+      {reviewStoriesStore.error ? (
+        <p>Failed to load stories. Please try refreshing the page.</p>
+      ) : null}
 
       {!reviewStoriesStore.isLoading &&
       !reviewStoriesStore.error &&

--- a/frontend/src/screens/App/screens/Admin/screens/ReviewStories/stores/ReviewStoriesStore.ts
+++ b/frontend/src/screens/App/screens/Admin/screens/ReviewStories/stores/ReviewStoriesStore.ts
@@ -5,6 +5,8 @@ import { immer } from 'zustand/middleware/immer';
 
 interface State {
   stories: AdminStory[];
+  isLoading: boolean;
+  error: boolean;
 }
 
 interface Actions {
@@ -16,11 +18,25 @@ interface Actions {
 const useReviewStoriesStore = create(
   immer<State & Actions>((set) => ({
     stories: [],
+    isLoading: false,
+    error: false,
     loadStories: async () => {
-      const stories = await getStoriesForReview();
       set((state) => {
-        state.stories = stories;
+        state.isLoading = true;
+        state.error = false;
       });
+      try {
+        const stories = await getStoriesForReview();
+        set((state) => {
+          state.stories = stories;
+          state.isLoading = false;
+        });
+      } catch (e) {
+        set((state) => {
+          state.error = true;
+          state.isLoading = false;
+        });
+      }
     },
     approveStory: async (storyId: AdminStory['id']) => {
       await updateStoryState(storyId, StoryState.PUBLISHED);

--- a/frontend/src/screens/App/screens/Admin/screens/ReviewStories/stores/ReviewStoriesStore.ts
+++ b/frontend/src/screens/App/screens/Admin/screens/ReviewStories/stores/ReviewStoriesStore.ts
@@ -29,11 +29,13 @@ const useReviewStoriesStore = create(
         const stories = await getStoriesForReview();
         set((state) => {
           state.stories = stories;
-          state.isLoading = false;
         });
       } catch (e) {
         set((state) => {
           state.error = true;
+        });
+      } finally {
+        set((state) => {
           state.isLoading = false;
         });
       }


### PR DESCRIPTION
## Summary
- Differentiates loading, empty, and error states on the admin Review Stories screen with plain text (no new components)
- `ReviewStoriesStore` now tracks `isLoading`/`error` around `loadStories`

🤖 Generated with [Claude Code](https://claude.com/claude-code)